### PR TITLE
Split Button + Button Fixes

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -23,6 +23,7 @@
       "ignorePackages",
       { "ts": "never", "tsx": "never" }
     ],
+    "no-unused-vars": 0,
     "react/jsx-filename-extension": ["warn", { "extensions": [".tsx"] }],
     "import/no-extraneous-dependencies": ["error", { "devDependencies": true }],
     "import/prefer-default-export": "off",

--- a/src/components/button/button.stories.tsx
+++ b/src/components/button/button.stories.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { ComponentStory, ComponentMeta } from '@storybook/react';
 import DownhillSkiingIcon from '@mui/icons-material/DownhillSkiing';
+import { action } from '@storybook/addon-actions';
 
 import { Button } from '..';
 
@@ -25,7 +26,7 @@ export default {
   },
 } as ComponentMeta<typeof Button>;
 
-const Template: ComponentStory<typeof Button> = (args) => <Button {...args} />;
+const Template: ComponentStory<typeof Button> = (args) => <Button onClick={action('button clicked')} {...args} />;
 
 const commonArgs = {
   children: 'Button',

--- a/src/components/button/button.stories.tsx
+++ b/src/components/button/button.stories.tsx
@@ -3,32 +3,28 @@ import { ComponentStory, ComponentMeta } from '@storybook/react';
 import DownhillSkiingIcon from '@mui/icons-material/DownhillSkiing';
 
 import { Button } from '..';
-// More on default export: https://storybook.js.org/docs/react/writing-stories/introduction#default-export
+
 export default {
   title: 'Buttons/Button',
   component: Button,
-  // More on argTypes: https://storybook.js.org/docs/react/api/argtypes
   argTypes: {
-    color: {
-      options: ['primary', 'secondary', 'inherit'],
-      control: 'radio',
-    },
     startIcon: {
       control: 'boolean',
       mapping: {
         true: <DownhillSkiingIcon />,
       },
+      defaultValue: false,
     },
     endIcon: {
       control: 'boolean',
       mapping: {
         true: <DownhillSkiingIcon />,
       },
+      defaultValue: false,
     },
   },
 } as ComponentMeta<typeof Button>;
 
-// More on component templates: https://storybook.js.org/docs/react/writing-stories/introduction#using-args
 const Template: ComponentStory<typeof Button> = (args) => <Button {...args} />;
 
 const commonArgs = {
@@ -43,12 +39,16 @@ Primary.args = {
   color: 'primary',
 };
 
+Primary.parameters = { controls: { include: ['disabled', 'children', 'startIcon', 'endIcon'] } };
+
 export const Secondary = Template.bind({});
 Secondary.args = {
   ...commonArgs,
   variant: 'contained',
   color: 'secondary',
 };
+
+Secondary.parameters = { controls: { include: ['disabled', 'children', 'startIcon', 'endIcon'] } };
 
 export const Stroked = Template.bind({});
 Stroked.args = {
@@ -57,9 +57,13 @@ Stroked.args = {
   color: 'primary',
 };
 
+Stroked.parameters = { controls: { include: ['disabled', 'children', 'startIcon', 'endIcon'] } };
+
 export const NoContainer = Template.bind({});
-// More on args: https://storybook.js.org/docs/react/writing-stories/args
 NoContainer.args = {
   ...commonArgs,
   variant: 'text',
+  color: 'inherit',
 };
+
+NoContainer.parameters = { controls: { include: ['disabled', 'children', 'startIcon', 'endIcon'] } };

--- a/src/components/button/button.tsx
+++ b/src/components/button/button.tsx
@@ -27,6 +27,12 @@ const StyledButton = styled(MuiButton)(({ theme }) => ({
     backgroundColor: 'transparent',
     color: theme.palette.text.placeholder,
   },
+  '&.MuiButton-outlinedPrimary': {
+    '&:focus, &:hover': {
+      backgroundColor: theme.palette.primary.main,
+      color: theme.palette.text.white,
+    },
+  },
 }));
 
 const Button: React.FC<ButtonProps> = (props) => <StyledButton {...props} />;

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -4,6 +4,9 @@ export * from './button';
 export { default as ToggleButtonGroup } from './toggle-button-group';
 export * from './toggle-button-group';
 
+export { default as SplitButton } from './split-button';
+export * from './split-button';
+
 export { default as SetupCard } from './setup-card';
 export * from './setup-card';
 

--- a/src/components/split-button/index.ts
+++ b/src/components/split-button/index.ts
@@ -1,0 +1,1 @@
+export { default } from './split-button';

--- a/src/components/split-button/split-button.stories.tsx
+++ b/src/components/split-button/split-button.stories.tsx
@@ -1,4 +1,5 @@
-import React, { useState } from 'react';
+import React from 'react';
+import { action } from '@storybook/addon-actions';
 import { ComponentStory, ComponentMeta } from '@storybook/react';
 import SplitButton from './split-button';
 
@@ -7,54 +8,31 @@ export default {
   component: SplitButton,
 } as ComponentMeta<typeof SplitButton>;
 
-const Template: ComponentStory<typeof SplitButton> = (args:any) => {
-  const [open, setOpen] = React.useState(false);
-  const [selectedIndex, setSelectedIndex] = useState(1);
-  const anchorRef = React.useRef<HTMLDivElement>(null);
+const Template: ComponentStory<typeof SplitButton> = (args:any) => (
+  <SplitButton
+    handleClick={action('button-click')}
+    {...args}
+  />
+);
 
-  const handleClick = () => {
-    console.log('clicked');
-  };
-
-  const handleMenuItemClick = (
-    event: React.MouseEvent<HTMLLIElement, MouseEvent>,
-    index: number,
-  ) => {
-    setSelectedIndex(index);
-    setOpen(false);
-  };
-
-  const handleToggle = () => {
-    setOpen((prevOpen) => !prevOpen);
-  };
-
-  const handleClose = (event: Event) => {
-    if (
-      anchorRef.current
-      && anchorRef.current.contains(event.target as HTMLElement)
-    ) {
-      return;
-    }
-
-    setOpen(false);
-  };
-
-  return (
-    <SplitButton
-      handleClick={handleClick}
-      selectedIndex={selectedIndex}
-      handleMenuItemClick={handleMenuItemClick}
-      handleToggle={handleToggle}
-      handleClose={handleClose}
-      open={open}
-      anchorRef={anchorRef}
-      {...args}
-    />
-  );
-};
-
-export const SplitButtonDefault = Template.bind({});
-SplitButtonDefault.args = {
+const commonArgs = {
   options: ['Create a merge commit', 'Squash and merge', 'Rebase and merge'],
-  ariaLabel: 'split button example',
+  ariaLabelGroup: 'split button example',
+  disabled: false,
 };
+
+export const Primary = Template.bind({});
+Primary.args = {
+  ...commonArgs,
+  color: 'primary',
+};
+
+Primary.parameters = { controls: { include: ['disabled', 'options'] } };
+
+export const Secondary = Template.bind({});
+Secondary.args = {
+  ...commonArgs,
+  color: 'secondary',
+};
+
+Secondary.parameters = { controls: { include: ['disabled', 'options'] } };

--- a/src/components/split-button/split-button.stories.tsx
+++ b/src/components/split-button/split-button.stories.tsx
@@ -1,0 +1,60 @@
+import React, { useState } from 'react';
+import { ComponentStory, ComponentMeta } from '@storybook/react';
+import SplitButton from './split-button';
+
+export default {
+  title: 'Buttons/SplitButton',
+  component: SplitButton,
+} as ComponentMeta<typeof SplitButton>;
+
+const Template: ComponentStory<typeof SplitButton> = (args:any) => {
+  const [open, setOpen] = React.useState(false);
+  const [selectedIndex, setSelectedIndex] = useState(1);
+  const anchorRef = React.useRef<HTMLDivElement>(null);
+
+  const handleClick = () => {
+    console.log('clicked');
+  };
+
+  const handleMenuItemClick = (
+    event: React.MouseEvent<HTMLLIElement, MouseEvent>,
+    index: number,
+  ) => {
+    setSelectedIndex(index);
+    setOpen(false);
+  };
+
+  const handleToggle = () => {
+    setOpen((prevOpen) => !prevOpen);
+  };
+
+  const handleClose = (event: Event) => {
+    if (
+      anchorRef.current
+      && anchorRef.current.contains(event.target as HTMLElement)
+    ) {
+      return;
+    }
+
+    setOpen(false);
+  };
+
+  return (
+    <SplitButton
+      handleClick={handleClick}
+      selectedIndex={selectedIndex}
+      handleMenuItemClick={handleMenuItemClick}
+      handleToggle={handleToggle}
+      handleClose={handleClose}
+      open={open}
+      anchorRef={anchorRef}
+      {...args}
+    />
+  );
+};
+
+export const SplitButtonDefault = Template.bind({});
+SplitButtonDefault.args = {
+  options: ['Create a merge commit', 'Squash and merge', 'Rebase and merge'],
+  ariaLabel: 'split button example',
+};

--- a/src/components/split-button/split-button.stories.tsx
+++ b/src/components/split-button/split-button.stories.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { action } from '@storybook/addon-actions';
 import { ComponentStory, ComponentMeta } from '@storybook/react';
 import SplitButton from './split-button';
@@ -8,12 +8,23 @@ export default {
   component: SplitButton,
 } as ComponentMeta<typeof SplitButton>;
 
-const Template: ComponentStory<typeof SplitButton> = (args:any) => (
-  <SplitButton
-    handleClick={action('button-click')}
-    {...args}
-  />
-);
+const Template: ComponentStory<typeof SplitButton> = (args:any) => {
+  const [selectedIndex, setSelectedIndex] = useState(1);
+  const { options } = args;
+
+  const handleIndexChange = (index:number) => {
+    setSelectedIndex(index);
+  };
+
+  return (
+    <SplitButton
+      selectedIndex={selectedIndex}
+      handleIndexChange={handleIndexChange}
+      handleClick={action(`${options[selectedIndex]} was clicked`)}
+      {...args}
+    />
+  );
+};
 
 const commonArgs = {
   options: ['Create a merge commit', 'Squash and merge', 'Rebase and merge'],

--- a/src/components/split-button/split-button.tsx
+++ b/src/components/split-button/split-button.tsx
@@ -1,0 +1,123 @@
+import React from 'react';
+import {
+  ButtonGroup,
+  ClickAwayListener,
+  Grow,
+  MenuItem,
+  MenuList,
+  Paper,
+  Popper,
+} from '@mui/material';
+import ArrowDropDownIcon from '@mui/icons-material/ArrowDropDown';
+import { styled } from '@mui/material/styles';
+import Button from '../button';
+
+interface SplitButtonProps {
+  options: Array<string>;
+  open: boolean,
+  handleClose: any,
+  handleClick: any,
+  handleMenuItemClick: any,
+  handleToggle: any,
+  selectedIndex: number,
+  anchorRef: any,
+  ariaLabel: string,
+}
+
+// eslint-disable-next-line max-len
+// const StyledToggleButtonGroup = styled(MuiToggleButtonGroup, {
+//   shouldForwardProp: (props) => props !== 'numOfButtons',
+//   name: 'WmeToggleButtonGroup',
+//   slot: 'Root',
+// })<ToggleButtonGroupProps>(({ theme }) => ({
+//   '.MuiToggleButton-root': {
+//     border: `1px solid ${theme.palette.text.primary}`,
+//     color: theme.palette.text.primary,
+//     textTransform: 'none',
+//     padding: '6px 12px',
+//     '&.Mui-selected': {
+//       backgroundColor: theme.palette.primary.main,
+//       color: theme.palette.text.white,
+
+//       '&:hover, &:focus': {
+//         backgroundColor: theme.palette.primary.main,
+//         color: theme.palette.text.white,
+//       },
+//     },
+//   },
+// }));
+
+const StyledPopper = styled(Popper, {
+  name: 'WmePopper',
+  slot: 'Root',
+})(() => ({
+  marginLeft: '16px',
+  marginTop: '54px',
+}));
+
+// eslint-disable-next-line max-len
+const SplitButton: React.FC<SplitButtonProps> = (props) => {
+  const {
+    open,
+    anchorRef,
+    handleClose,
+    options,
+    selectedIndex,
+    handleMenuItemClick,
+    handleClick,
+    handleToggle,
+    ariaLabel,
+  } = props;
+
+  return (
+    <>
+      <ButtonGroup variant="contained">
+        <Button onClick={handleClick}>{options[selectedIndex]}</Button>
+        <Button
+          onClick={handleToggle}
+          aria-controls={open ? 'split-button-menu' : undefined}
+          aria-expanded={open ? 'true' : undefined}
+          aria-label={ariaLabel}
+          aria-haspopup="menu"
+        >
+          <ArrowDropDownIcon />
+        </Button>
+      </ButtonGroup>
+      <StyledPopper
+        open={open}
+        anchorEl={anchorRef.current}
+        role={undefined}
+        transition
+        disablePortal
+      >
+        {({ TransitionProps, placement }) => (
+          <Grow
+            {...TransitionProps}
+            style={{
+              transformOrigin:
+                placement === 'bottom' ? 'center top' : 'center bottom',
+            }}
+          >
+            <Paper>
+              <ClickAwayListener onClickAway={handleClose}>
+                <MenuList id="split-button-menu" autoFocusItem>
+                  {options.map((option:string, index:number) => (
+                    <MenuItem
+                      key={option}
+                      selected={index === selectedIndex}
+                      onClick={(event) => handleMenuItemClick(event, index)}
+                    >
+                      {option}
+                    </MenuItem>
+                  ))}
+                </MenuList>
+              </ClickAwayListener>
+            </Paper>
+          </Grow>
+        )}
+      </StyledPopper>
+    </>
+  );
+};
+
+export default SplitButton;

--- a/src/components/split-button/split-button.tsx
+++ b/src/components/split-button/split-button.tsx
@@ -14,15 +14,17 @@ import Button from '../button';
 
 /**
  * All the logic for the dropdown is handled in the component, but the developer will need to
- * pass in a click handler for when the actual button is clicked.
+ * pass in a click handler and keep track of the selected index for when the button is clicked.
 */
 
 interface SplitButtonProps {
   options: Array<string>;
   handleClick: () => void,
+  handleIndexChange: (arg:number) => void,
   ariaLabelGroup: string,
   color: 'primary' | 'secondary',
   disabled: boolean,
+  selectedIndex: number,
 }
 
 const StyledMenuItem = styled(MenuItem, {
@@ -61,12 +63,13 @@ const StyledList = styled(MenuList, {
 const SplitButton: React.FC<SplitButtonProps> = (props) => {
   const anchorRef = useRef<HTMLDivElement>(null);
   const [open, setOpen] = useState(false);
-  const [selectedIndex, setSelectedIndex] = useState(1);
 
   const {
     options,
     handleClick,
     ariaLabelGroup,
+    selectedIndex,
+    handleIndexChange,
     ...rest
   } = props;
 
@@ -89,7 +92,7 @@ const SplitButton: React.FC<SplitButtonProps> = (props) => {
     event: React.MouseEvent<HTMLLIElement, MouseEvent>,
     index: number,
   ) => {
-    setSelectedIndex(index);
+    handleIndexChange(index);
     setOpen(false);
   };
 

--- a/src/components/split-button/split-button.tsx
+++ b/src/components/split-button/split-button.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState, useRef } from 'react';
 import {
   ButtonGroup,
   ClickAwayListener,
@@ -12,110 +12,129 @@ import ArrowDropDownIcon from '@mui/icons-material/ArrowDropDown';
 import { styled } from '@mui/material/styles';
 import Button from '../button';
 
+/**
+ * All the logic for the dropdown is handled in the component, but the developer will need to
+ * pass in a click handler for when the actual button is clicked.
+*/
+
 interface SplitButtonProps {
   options: Array<string>;
-  open: boolean,
-  handleClose: any,
-  handleClick: any,
-  handleMenuItemClick: any,
-  handleToggle: any,
-  selectedIndex: number,
-  anchorRef: any,
-  ariaLabel: string,
+  handleClick: () => void,
+  ariaLabelGroup: string,
+  color: 'primary' | 'secondary',
+  disabled: boolean,
 }
 
-// eslint-disable-next-line max-len
-// const StyledToggleButtonGroup = styled(MuiToggleButtonGroup, {
-//   shouldForwardProp: (props) => props !== 'numOfButtons',
-//   name: 'WmeToggleButtonGroup',
-//   slot: 'Root',
-// })<ToggleButtonGroupProps>(({ theme }) => ({
-//   '.MuiToggleButton-root': {
-//     border: `1px solid ${theme.palette.text.primary}`,
-//     color: theme.palette.text.primary,
-//     textTransform: 'none',
-//     padding: '6px 12px',
-//     '&.Mui-selected': {
-//       backgroundColor: theme.palette.primary.main,
-//       color: theme.palette.text.white,
-
-//       '&:hover, &:focus': {
-//         backgroundColor: theme.palette.primary.main,
-//         color: theme.palette.text.white,
-//       },
-//     },
-//   },
-// }));
-
-const StyledPopper = styled(Popper, {
-  name: 'WmePopper',
+const StyledMenuItem = styled(MenuItem, {
+  name: 'WmeMenuItem',
   slot: 'Root',
-})(() => ({
-  marginLeft: '16px',
-  marginTop: '54px',
+})(({ theme }) => ({
+  '&.Mui-selected': {
+    backgroundColor: theme.palette.primary.main,
+    color: theme.palette.text.white,
+    '&:hover, &:focus': {
+      backgroundColor: theme.palette.primary.main,
+      color: theme.palette.text.white,
+    },
+  },
+  '&:hover': {
+    backgroundColor: theme.palette.background.hover,
+  },
 }));
 
-// eslint-disable-next-line max-len
+const StyledPaper = styled(Paper, {
+  name: 'WmePaper',
+  slot: 'Root',
+})(() => ({
+  borderRadius: 0,
+  boxShadow: '0px 0px 32px 0px #0000001A;',
+}));
+
+const StyledList = styled(MenuList, {
+  name: 'WmeMenuList',
+  slot: 'Root',
+})(() => ({
+  paddingTop: 0,
+  paddingBottom: 0,
+}));
+
 const SplitButton: React.FC<SplitButtonProps> = (props) => {
+  const anchorRef = useRef<HTMLDivElement>(null);
+  const [open, setOpen] = useState(false);
+  const [selectedIndex, setSelectedIndex] = useState(1);
+
   const {
-    open,
-    anchorRef,
-    handleClose,
     options,
-    selectedIndex,
-    handleMenuItemClick,
     handleClick,
-    handleToggle,
-    ariaLabel,
+    ariaLabelGroup,
+    ...rest
   } = props;
+
+  const handleToggle = () => {
+    setOpen((prevOpen) => !prevOpen);
+  };
+
+  const handleClose = (event: Event) => {
+    if (
+      anchorRef.current
+      && anchorRef.current.contains(event.target as HTMLElement)
+    ) {
+      return;
+    }
+
+    setOpen(false);
+  };
+
+  const handleMenuItemClick = (
+    event: React.MouseEvent<HTMLLIElement, MouseEvent>,
+    index: number,
+  ) => {
+    setSelectedIndex(index);
+    setOpen(false);
+  };
 
   return (
     <>
-      <ButtonGroup variant="contained">
+      <ButtonGroup variant="contained" ref={anchorRef} aria-label={ariaLabelGroup} {...rest}>
         <Button onClick={handleClick}>{options[selectedIndex]}</Button>
         <Button
           onClick={handleToggle}
           aria-controls={open ? 'split-button-menu' : undefined}
           aria-expanded={open ? 'true' : undefined}
-          aria-label={ariaLabel}
+          aria-label={options[selectedIndex]}
           aria-haspopup="menu"
         >
           <ArrowDropDownIcon />
         </Button>
       </ButtonGroup>
-      <StyledPopper
+      <Popper
         open={open}
         anchorEl={anchorRef.current}
         role={undefined}
         transition
         disablePortal
+        placement="bottom-start"
       >
-        {({ TransitionProps, placement }) => (
-          <Grow
-            {...TransitionProps}
-            style={{
-              transformOrigin:
-                placement === 'bottom' ? 'center top' : 'center bottom',
-            }}
-          >
-            <Paper>
+        {({ TransitionProps }) => (
+          <Grow {...TransitionProps}>
+            <StyledPaper>
               <ClickAwayListener onClickAway={handleClose}>
-                <MenuList id="split-button-menu" autoFocusItem>
+                <StyledList id="split-button-menu" autoFocusItem>
                   {options.map((option:string, index:number) => (
-                    <MenuItem
+                    <StyledMenuItem
                       key={option}
                       selected={index === selectedIndex}
                       onClick={(event) => handleMenuItemClick(event, index)}
                     >
                       {option}
-                    </MenuItem>
+                    </StyledMenuItem>
                   ))}
-                </MenuList>
+                </StyledList>
               </ClickAwayListener>
-            </Paper>
+            </StyledPaper>
           </Grow>
         )}
-      </StyledPopper>
+      </Popper>
     </>
   );
 };


### PR DESCRIPTION
### Description
https://moderntribe.atlassian.net/browse/FRAME-26
https://moderntribe.atlassian.net/browse/FRAME-8

- build out split buttons and stories
- fix buttons to only allow necessary controls for each variation
- add focused/hover state to stroked button
- remove `no-unused-vars` from .eslint. it was interfering with declaring types on functions

### Screencast
http://p.tri.be/3La2Nc

