### PR TITLE
Add classNames to Styled Components

### DIFF
--- a/src/components/button/button.tsx
+++ b/src/components/button/button.tsx
@@ -2,7 +2,10 @@ import React from 'react';
 import { Button as MuiButton, ButtonProps } from '@mui/material';
 import { styled } from '@mui/material/styles';
 
-const StyledButton = styled(MuiButton)(({ theme }) => ({
+const StyledButton = styled(MuiButton, {
+  name: 'WmeButton',
+  slot: 'Root',
+})(({ theme }) => ({
   textTransform: 'none',
   padding: '6px 12px',
   boxShadow: 'none',
@@ -35,6 +38,8 @@ const StyledButton = styled(MuiButton)(({ theme }) => ({
   },
 }));
 
-const Button: React.FC<ButtonProps> = (props) => <StyledButton {...props} />;
+const Button: React.FC<ButtonProps> = (props) => (
+  <StyledButton className={StyledButton.displayName} {...props} />
+);
 
 export default Button;

--- a/src/components/card-select-item/card-select-item.tsx
+++ b/src/components/card-select-item/card-select-item.tsx
@@ -180,6 +180,7 @@ export default function CardSelectItem(props: CardSelectItemProps) {
     ...rest
   } = props;
 
+  console.log(className);
   const { selected } = props;
 
   let primary = primaryProp != null ? primaryProp : children;

--- a/src/components/card-select-item/card-select-item.tsx
+++ b/src/components/card-select-item/card-select-item.tsx
@@ -180,7 +180,6 @@ export default function CardSelectItem(props: CardSelectItemProps) {
     ...rest
   } = props;
 
-  console.log(className);
   const { selected } = props;
 
   let primary = primaryProp != null ? primaryProp : children;

--- a/src/components/checkbox/checkbox.tsx
+++ b/src/components/checkbox/checkbox.tsx
@@ -46,7 +46,14 @@ const Checkbox: React.FC<CheckboxProps> = (props) => {
         inputLabel
         && <InputTitle>{inputLabel}</InputTitle>
       }
-      <FormControlLabel control={<StyledCheckbox />} {...rest} />
+      <FormControlLabel
+        control={(
+          <StyledCheckbox
+            className={StyledCheckbox.displayName}
+          />
+        )}
+        {...rest}
+      />
       {
         (error && errorMessage)
         && <ErrorText sx={{ marginTop: 0 }}>{errorMessage}</ErrorText>

--- a/src/components/chip/chip.tsx
+++ b/src/components/chip/chip.tsx
@@ -29,5 +29,5 @@ const StyledChip = styled(MuiChip)<ChipProps>(({ color, size, theme }) => ({
 }));
 
 export default function Chip(props: ChipProps) {
-  return <StyledChip {...props} />;
+  return <StyledChip className={StyledChip.displayName} {...props} />;
 }

--- a/src/components/dropdown/dropdown.tsx
+++ b/src/components/dropdown/dropdown.tsx
@@ -96,7 +96,10 @@ const Dropdown: React.FC<WmeDropdownProps> = (props) => {
   });
 
   return (
-    <StyledFormControl width={width}>
+    <StyledFormControl
+      width={width}
+      className={StyledFormControl.displayName}
+    >
       {
         labelText
         && (
@@ -110,6 +113,7 @@ const Dropdown: React.FC<WmeDropdownProps> = (props) => {
         error={error}
         value={value}
         input={<OutlinedInput />}
+        className={StyledSelect.displayName}
         renderValue={(selected: any) => {
           if (selected.length === 0 || typeof selected === 'string') {
             return selectValue;

--- a/src/components/error-text/error-text.tsx
+++ b/src/components/error-text/error-text.tsx
@@ -13,9 +13,10 @@ const StyledText = styled(Typography, {
 
 const ErrorText: React.FC<TypographyProps> = (props) => {
   const { children } = props;
+  const { displayName } = StyledText;
 
   return (
-    <StyledText {...props}>
+    <StyledText className={displayName} {...props}>
       {children}
     </StyledText>
   );

--- a/src/components/file-upload/file-upload.tsx
+++ b/src/components/file-upload/file-upload.tsx
@@ -143,7 +143,7 @@ const TitleContainer: React.FC<TitleContainerProps> = (props) => {
   } = props;
 
   return (
-    <StyledTitleContainer>
+    <StyledTitleContainer className={StyledTitleContainer.displayName}>
       {
         label
         && <InputTitle>{label}</InputTitle>
@@ -171,12 +171,12 @@ const FileUpload: React.FC<FileUploadProps> = (props) => {
   } = props;
 
   return (
-    <Container>
+    <Container className={Container.displayName}>
       {
         label
         && <TitleContainer {...props} />
       }
-      <FileUploadBox error={error}>
+      <FileUploadBox className={FileUploadBox.displayName} error={error}>
         {
           !selectedFile || error
             ? (

--- a/src/components/form-control-label/form-control-label.tsx
+++ b/src/components/form-control-label/form-control-label.tsx
@@ -1,8 +1,8 @@
 import React, { ReactElement } from 'react';
 import { styled } from '@mui/material/styles';
-import { FormControlLabel as MuiFormControlLabel } from '@mui/material';
+import { FormControlLabel as MuiFormControlLabel, FormControlLabelProps } from '@mui/material';
 
-interface FormControlProps {
+interface FormControlProps extends FormControlLabelProps {
   control: ReactElement;
   label: string;
   value?: string;
@@ -12,7 +12,7 @@ interface FormControlProps {
 const StyledFormControlLabel = styled(MuiFormControlLabel, {
   name: 'WmeFormControlLabel',
   slot: 'Root',
-})(() => ({
+})<FormControlProps>(() => ({
   '& .MuiTypography-root': {
     fontSize: 14,
     textAlign: 'left',
@@ -21,8 +21,10 @@ const StyledFormControlLabel = styled(MuiFormControlLabel, {
 
 const FormControlLabel: React.FC<FormControlProps> = (props) => {
   const { children, ...rest } = props;
+  const { displayName } = StyledFormControlLabel;
+
   return (
-    <StyledFormControlLabel {...rest}>
+    <StyledFormControlLabel className={displayName} {...rest}>
       {children}
     </StyledFormControlLabel>
   );

--- a/src/components/form-helper-text/form-helper-text.tsx
+++ b/src/components/form-helper-text/form-helper-text.tsx
@@ -16,8 +16,10 @@ const StyledFormHelperText = styled(MuiFormHelperText, {
 
 const FormHelperText: React.FC<FormHelperTextProps> = (props) => {
   const { children } = props;
+  const { displayName } = StyledFormHelperText;
+
   return (
-    <StyledFormHelperText {...props}>
+    <StyledFormHelperText className={displayName} {...props}>
       {children}
     </StyledFormHelperText>
   );

--- a/src/components/input-title/input-title.tsx
+++ b/src/components/input-title/input-title.tsx
@@ -19,8 +19,9 @@ const StyledInputTitle = styled(Typography, {
 
 const InputTitle: React.FC<InputTitleProps> = (props) => {
   const { children } = props;
+  const { displayName } = StyledInputTitle;
   return (
-    <StyledInputTitle>
+    <StyledInputTitle className={displayName}>
       {children}
     </StyledInputTitle>
   );

--- a/src/components/menu-item/menu-item.tsx
+++ b/src/components/menu-item/menu-item.tsx
@@ -31,8 +31,10 @@ const StyledMenuItem = styled(MuiMenuItem, {
 
 const MenuItem: React.FC<WmeMenuItemProps> = (props) => {
   const { children, icon } = props;
+  const { displayName } = StyledMenuItem;
+
   return (
-    <StyledMenuItem {...props}>
+    <StyledMenuItem className={displayName} {...props}>
       {children}
       {icon
       && (

--- a/src/components/nav-number/nav-number.tsx
+++ b/src/components/nav-number/nav-number.tsx
@@ -63,8 +63,8 @@ const NavNumber: React.FC<NavNumberProps> = (props) => {
   } = props;
 
   return (
-    <StyledNavBlock {...rest}>
-      <StyledCircle>
+    <StyledNavBlock className={StyledNavBlock.displayName} {...rest}>
+      <StyledCircle className={StyledCircle.displayName}>
         {
           // eslint-disable-next-line react/destructuring-assignment
           props.isComplete
@@ -72,7 +72,7 @@ const NavNumber: React.FC<NavNumberProps> = (props) => {
             : number
         }
       </StyledCircle>
-      <StyledText>
+      <StyledText className={StyledText.displayName}>
         {text}
       </StyledText>
     </StyledNavBlock>

--- a/src/components/navigation/navigation.tsx
+++ b/src/components/navigation/navigation.tsx
@@ -18,7 +18,7 @@ export const Navigation: React.FC<NavigationProps> = (props) => {
 
   return (
     <div role="presentation">
-      <StyledNavigation {...rest}>
+      <StyledNavigation className={StyledNavigation.displayName} {...rest}>
         {children}
       </StyledNavigation>
     </div>

--- a/src/components/password-field/password-field.tsx
+++ b/src/components/password-field/password-field.tsx
@@ -78,13 +78,14 @@ const PasswordField: React.FC<PasswordFieldProps> = (props) => {
         type={showPassword ? 'text' : 'password'}
         error={error}
         endAdornment={(
-          <StyledInputAdornment position="end">
+          <StyledInputAdornment className={StyledInputAdornment.displayName} position="end">
             {
               value?.length > 0
               && (
                 <StyledChip
                   label={chipLabel}
                   color={color}
+                  className={StyledChip.displayName}
                 />
               )
             }

--- a/src/components/progress-bar/progress-bar.tsx
+++ b/src/components/progress-bar/progress-bar.tsx
@@ -44,19 +44,28 @@ export default function ProgressBar(props: ProgressBarProps) {
   const { value, statusMessage } = props;
   const percentage = typeof value !== 'undefined' ? Math.round(value) : 0;
   return (
-    <StyledProgressBarWrapper>
+    <StyledProgressBarWrapper className={StyledProgressBarWrapper.displayName}>
       <StyledProgressBar
         aria-label="progress bar"
         variant="determinate"
+        className={StyledProgressBar.displayName}
         {...props}
       />
       <StyledProgressBarPercentage
         variant="caption"
+        className={StyledProgressBarPercentage.displayName}
       >
         {`${percentage}%`}
       </StyledProgressBarPercentage>
       { statusMessage
-      && <StyledProgressBarStatusMessage variant="caption">{statusMessage}</StyledProgressBarStatusMessage> }
+      && (
+        <StyledProgressBarStatusMessage
+          className={StyledProgressBarStatusMessage.displayName}
+          variant="caption"
+        >
+            {statusMessage}
+        </StyledProgressBarStatusMessage>
+      )}
     </StyledProgressBarWrapper>
   );
 }

--- a/src/components/radio-button-group/radio-button-group.tsx
+++ b/src/components/radio-button-group/radio-button-group.tsx
@@ -38,7 +38,11 @@ const RadioButtonGroup: React.FC<RadioButtonGroupProps> = (props) => {
 
   return (
     <FormControl>
-      <StyledRadioGroup aria-labelledby={ariaLabelledby} {...rest}>
+      <StyledRadioGroup
+        className={StyledRadioGroup.displayName}
+        aria-labelledby={ariaLabelledby}
+        {...rest}
+      >
         {children}
       </StyledRadioGroup>
       <RadioGroup />

--- a/src/components/setup-card-footer/setup-card-footer.tsx
+++ b/src/components/setup-card-footer/setup-card-footer.tsx
@@ -37,8 +37,10 @@ const SetupCardFooterWrapper = styled(Box, {
 
 const SetupCardFooter: React.FC<BoxProps> = (props) => {
   const { children } = props;
+  const { displayName } = SetupCardFooterWrapper;
+
   return (
-    <SetupCardFooterWrapper>
+    <SetupCardFooterWrapper className={displayName}>
       { children }
     </SetupCardFooterWrapper>
   );

--- a/src/components/setup-card-header/setup-card-header.tsx
+++ b/src/components/setup-card-header/setup-card-header.tsx
@@ -19,5 +19,7 @@ StyledSetupCardHeader.defaultProps = {
 };
 
 export default function SetupCardHeader(props: CardHeaderProps) {
-  return <StyledSetupCardHeader {...props} />;
+  const { displayName } = StyledSetupCardHeader;
+
+  return <StyledSetupCardHeader className={displayName} {...props} />;
 }

--- a/src/components/setup-card-list-item/setup-card-list-item.tsx
+++ b/src/components/setup-card-list-item/setup-card-list-item.tsx
@@ -61,10 +61,21 @@ export default function SetupCardListItem(props: SetupCardListItemProps) {
         target={target}
         variant="body1"
         underline="none"
+        className={StyledSetupCardListItem.displayName}
         {...linkProps}
       >
-        { icon && <StyledSetupCardIconWrapper>{icon}</StyledSetupCardIconWrapper> }
-        <StyledSetupCardTextWrapper>{title}</StyledSetupCardTextWrapper>
+        { icon && (
+          <StyledSetupCardIconWrapper
+            className={StyledSetupCardIconWrapper.displayName}
+          >
+            {icon}
+          </StyledSetupCardIconWrapper>
+        )}
+        <StyledSetupCardTextWrapper
+          className={StyledSetupCardTextWrapper.displayName}
+        >
+          {title}
+        </StyledSetupCardTextWrapper>
       </Link>
     </StyledSetupCardListItem>
   );

--- a/src/components/setup-card-list/setup-card-list.tsx
+++ b/src/components/setup-card-list/setup-card-list.tsx
@@ -12,5 +12,7 @@ const StyledSetupCardList = styled(List, {
 }));
 
 export default function SetupCardList(props: ListProps) {
-  return <StyledSetupCardList dense disablePadding {...props} />;
+  const { displayName } = StyledSetupCardList;
+
+  return <StyledSetupCardList className={displayName} dense disablePadding {...props} />;
 }

--- a/src/components/setup-card-task/setup-card-task.tsx
+++ b/src/components/setup-card-task/setup-card-task.tsx
@@ -129,7 +129,7 @@ const SetupCardTask: React.FC<SetupCardProps> = (props) => {
   const variantType = variant === 'action' ? 'action' : 'task';
 
   return (
-    <Task variant={variantType}>
+    <Task className={Task.displayName} variant={variantType}>
       <ConditionalWrapper
         condition={variantType === 'task'}
         wrapper={
@@ -156,8 +156,8 @@ const SetupCardTask: React.FC<SetupCardProps> = (props) => {
           </Button>
         )
           : (
-            <SetupCardTaskCta>
-              <CtaAction variant="body1">
+            <SetupCardTaskCta className={SetupCardTaskCta.displayName}>
+              <CtaAction className={CtaAction.displayName} variant="body1">
                 {taskCta}
               </CtaAction>
               <ChevronRight />

--- a/src/components/setup-card/setup-card.tsx
+++ b/src/components/setup-card/setup-card.tsx
@@ -23,5 +23,6 @@ const StyledSetupCard = styled(Card, {
 }));
 
 export default function SetupCard(props: CardProps) {
-  return <StyledSetupCard {...props} />;
+  const { displayName } = StyledSetupCard;
+  return <StyledSetupCard className={displayName} {...props} />;
 }

--- a/src/components/split-button/split-button.tsx
+++ b/src/components/split-button/split-button.tsx
@@ -109,7 +109,13 @@ const SplitButton: React.FC<SplitButtonProps> = (props) => {
 
   return (
     <>
-      <StyledButtonGroup variant="contained" ref={anchorRef} aria-label={ariaLabelGroup} {...rest}>
+      <StyledButtonGroup
+        variant="contained"
+        ref={anchorRef}
+        aria-label={ariaLabelGroup}
+        className={StyledButtonGroup.displayName}
+        {...rest}
+      >
         <Button onClick={handleClick}>{options[selectedIndex]}</Button>
         <Button
           onClick={handleToggle}
@@ -131,13 +137,14 @@ const SplitButton: React.FC<SplitButtonProps> = (props) => {
       >
         {({ TransitionProps }) => (
           <Grow {...TransitionProps}>
-            <StyledPaper>
+            <StyledPaper className={StyledPaper.displayName}>
               <ClickAwayListener onClickAway={handleClose}>
-                <StyledList id="split-button-menu" autoFocusItem>
+                <StyledList className={StyledList.displayName} id="split-button-menu" autoFocusItem>
                   {options.map((option:string, index:number) => (
                     <StyledMenuItem
                       key={option}
                       selected={index === selectedIndex}
+                      className={StyledMenuItem.displayName}
                       onClick={(event) => handleMenuItemClick(event, index)}
                     >
                       {option}

--- a/src/components/text-field/text-field.tsx
+++ b/src/components/text-field/text-field.tsx
@@ -71,7 +71,7 @@ const TextField: React.FC<TextFieldProps> = (props) => {
       <InputTitle>
         {label}
       </InputTitle>
-      <StyledInputBase error={error} {...rest} />
+      <StyledInputBase className={StyledInputBase.displayName} error={error} {...rest} />
       {
         (error && errorMessage)
         && (

--- a/src/components/toggle-button-group/toggle-button-group.tsx
+++ b/src/components/toggle-button-group/toggle-button-group.tsx
@@ -39,6 +39,7 @@ const ToggleButtonGroup: React.FC<ToggleButtonGroupProps> = (props) => {
     <StyledToggleButtonGroup
       exclusive
       aria-label={ariaLabel}
+      className={StyledToggleButtonGroup.displayName}
       {...rest}
     >
       { children }

--- a/src/components/tooltip/tooltip.tsx
+++ b/src/components/tooltip/tooltip.tsx
@@ -17,7 +17,7 @@ const Tooltip: React.FC<TooltipProps> = (props) => {
   const { children, ...rest } = props;
 
   return (
-    <StyledTooltip arrow {...rest}>
+    <StyledTooltip className={StyledTooltip.displayName} arrow {...rest}>
       {children}
     </StyledTooltip>
   );

--- a/src/components/video-embed/video-embed.tsx
+++ b/src/components/video-embed/video-embed.tsx
@@ -41,8 +41,8 @@ const VideoEmbed: React.FC<VideoEmbedProps> = (props) => {
   };
 
   return (
-    <StyledContainer>
-      <StyledMedia {...videoProps} />
+    <StyledContainer className={StyledContainer.displayName}>
+      <StyledMedia className={StyledMedia.displayName} {...videoProps} />
     </StyledContainer>
   );
 };

--- a/src/components/wizard-footer/wizard-footer.tsx
+++ b/src/components/wizard-footer/wizard-footer.tsx
@@ -172,6 +172,7 @@ const WizardFooter: React.FC<WizardFooterProps> = (props) => {
                   <Step key={step.id} active={unlocked} completed={unlocked && !isCurrentStep}>
                     <StyledStepButton
                       disabled={disable}
+                      className={StyledStepButton.displayName}
                       onClick={() => onClickStep?.(step)}
                       sx={{ '&:hover': { textDecoration: unlocked ? 'underline' : 'none' } }}
                     >

--- a/src/components/wizard-footer/wizard-footer.tsx
+++ b/src/components/wizard-footer/wizard-footer.tsx
@@ -140,8 +140,8 @@ const WizardFooter: React.FC<WizardFooterProps> = (props) => {
 
   if (!hideFooter) {
     return (
-      <WizardFooterContainer>
-        <Prev>
+      <WizardFooterContainer className={WizardFooterContainer.displayName}>
+        <Prev className={Prev.displayName}>
           {
             !currStep?.hideBack
             && (
@@ -155,8 +155,12 @@ const WizardFooter: React.FC<WizardFooterProps> = (props) => {
             )
           }
         </Prev>
-        <Nav>
-          <StyledStepper activeStep={maxActiveStep} connector={null}>
+        <Nav className={Nav.displayName}>
+          <StyledStepper
+            activeStep={maxActiveStep}
+            connector={null}
+            className={StyledStepper.displayName}
+          >
             {
               steps?.map((step) => {
                 if (step.id > steps.length || step.hidePagination) {
@@ -179,8 +183,8 @@ const WizardFooter: React.FC<WizardFooterProps> = (props) => {
             }
           </StyledStepper>
         </Nav>
-        <Next>
-          <Skip>
+        <Next className={Next.displayName}>
+          <Skip className={Skip.displayName}>
             {
               !currStep?.hideSkip
               && (
@@ -207,6 +211,8 @@ const WizardFooter: React.FC<WizardFooterProps> = (props) => {
                     color="primary"
                     onClick={isLastStep ? save : onNext}
                     disabled={(disableNext || currStep?.disableNext || disable)}
+                    className="WmeWizardFooterNextButton"
+                    endIcon={<ChevronRight />}
                   >
                     {nextText}
                   </Button>

--- a/src/components/wizard-header/wizard-header.tsx
+++ b/src/components/wizard-header/wizard-header.tsx
@@ -46,15 +46,15 @@ const WizardHeader: React.FC<WizardHeaderProps> = (props) => {
   } = props;
 
   return (
-    <WizardHeaderContainer>
-      <LogoContainer>
+    <WizardHeaderContainer className={WizardHeaderContainer.displayName}>
+      <LogoContainer className={LogoContainer.displayName}>
         {
           logoSrc
           && <img src={logoSrc} alt={logoAlt} />
         }
       </LogoContainer>
       {centerContent}
-      <ExitContainer>
+      <ExitContainer className={ExitContainer.displayName}>
         {exit}
       </ExitContainer>
     </WizardHeaderContainer>

--- a/src/components/wizard-section-title/wizard-section-title.tsx
+++ b/src/components/wizard-section-title/wizard-section-title.tsx
@@ -59,12 +59,21 @@ const WizardSectionTitle: React.FC<WizardSectionTitleProps> = (props) => {
   const { displayName } = WizardSectionTitleContainer;
 
   return (
-    <WizardSectionTitleContainer className={displayName} width={width} bookend={bookend} {...rest}>
+    <WizardSectionTitleContainer
+      className={displayName}
+      width={width}
+      bookend={bookend}
+      {...rest}
+    >
       {
         iconSrc
-        && <IconContainer><img src={iconSrc} alt={iconAlt} width={iconWidth} /></IconContainer>
+        && (
+          <IconContainer className={IconContainer.displayName}>
+            <img src={iconSrc} alt={iconAlt} width={iconWidth} />
+          </IconContainer>
+        )
       }
-      <Heading variant={headingVariant || 'h2'}>{heading}</Heading>
+      <Heading className={Heading.displayName} variant={headingVariant || 'h2'}>{heading}</Heading>
       <Typography variant="body1" align={copyAlign && !bookend ? copyAlign : 'inherit'}>{copy}</Typography>
     </WizardSectionTitleContainer>
   );

--- a/src/components/wizard-section-title/wizard-section-title.tsx
+++ b/src/components/wizard-section-title/wizard-section-title.tsx
@@ -56,8 +56,10 @@ const WizardSectionTitle: React.FC<WizardSectionTitleProps> = (props) => {
     ...rest
   } = props;
 
+  const { displayName } = WizardSectionTitleContainer;
+
   return (
-    <WizardSectionTitleContainer width={width} bookend={bookend} {...rest}>
+    <WizardSectionTitleContainer className={displayName} width={width} bookend={bookend} {...rest}>
       {
         iconSrc
         && <IconContainer><img src={iconSrc} alt={iconAlt} width={iconWidth} /></IconContainer>

--- a/src/components/wizard/wizard.tsx
+++ b/src/components/wizard/wizard.tsx
@@ -37,6 +37,8 @@ const Wizard: React.FC<WmeDialogProps> = (props) => {
     ...rest
   } = props;
 
+  const { displayName } = StyledDialogContent;
+
   return (
     <Dialog
       fullScreen
@@ -44,7 +46,7 @@ const Wizard: React.FC<WmeDialogProps> = (props) => {
       {...rest}
     >
       <Box sx={{ ...bgStyles }}>
-        <StyledDialogContent>
+        <StyledDialogContent className={displayName}>
           {children}
         </StyledDialogContent>
       </Box>


### PR DESCRIPTION
### Description
- https://moderntribe.atlassian.net/browse/FRAME-40
- Solves the issue of not being able to apply styleOverrides
- Applies a className to each WME Styled component
- Since emotion uses refs, we can use the `Component.displayName` prop to output the class name dynamically

I tried to use destructuring where applicable, but if there were multiple styled components I just accessed the prop directly. 