### PR TITLE
[WME-224] Updates to SetupCardTask component and story

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@moderntribe/wme",
-  "version": "0.1.14",
+  "version": "0.1.15",
   "private": false,
   "author": "Moderntribe Incubator Team",
   "description": "Components and hooks to build the best UX/UI admin wizards",

--- a/src/components/setup-card-task/setup-card-task.stories.mdx
+++ b/src/components/setup-card-task/setup-card-task.stories.mdx
@@ -127,6 +127,8 @@ specific part of the WordPress admin.
   <Story
     name="Task"
     args={{
+      id: 'task1',
+      url: 'https://tri.be',
       title: 'Example task title',
       variant: 'task',
       taskCta: 'Learn More',
@@ -140,6 +142,8 @@ specific part of the WordPress admin.
   <Story
     name="TaskDisabled"
     args={{
+      id: 'task2',
+      url: 'https://tri.be',
       variant: 'task',
       title: 'Example disabled task',
       taskCta: 'Learn More',
@@ -154,6 +158,7 @@ specific part of the WordPress admin.
   <Story
     name="Action"
     args={{
+      id: 'action1',
       title: 'Example task with Action',
       variant: 'action',
       button: {
@@ -171,6 +176,7 @@ specific part of the WordPress admin.
   <Story
     name="ActionDisabled"
     args={{
+      id: 'action2',
       title: 'Example task with disabled Action',
       disabled: true,
       variant: 'action',

--- a/src/components/setup-card-task/setup-card-task.tsx
+++ b/src/components/setup-card-task/setup-card-task.tsx
@@ -3,6 +3,7 @@ import {
   Box,
   BoxProps,
   CardActionArea,
+  CardActionAreaProps,
   Typography,
   TypographyProps,
   Avatar,
@@ -26,6 +27,8 @@ interface TaskButton extends ButtonProps {
 }
 
 interface SetupCardProps extends BoxProps {
+  id: string;
+  url?: string;
   title?: string;
   intro?: string;
   children?: React.ReactNode;
@@ -41,6 +44,10 @@ interface SetupCardProps extends BoxProps {
 interface TaskProps extends BoxProps {
   variant?: TaskVariant;
   button?: boolean;
+}
+
+interface TaskActionAreaProps extends CardActionAreaProps {
+  href?: string;
 }
 
 const Task = styled(Box, {
@@ -80,7 +87,7 @@ const Task = styled(Box, {
       marginRight: theme.spacing(-1.5),
       marginLeft: theme.spacing(-1.5),
 
-      '& > button': {
+      '& > button, & > a': {
         display: 'flex',
         padding: theme.spacing(1.5),
         justifyContent: 'flex-start',
@@ -88,8 +95,12 @@ const Task = styled(Box, {
         borderRadius: theme.shape.borderRadius,
       },
 
-      '& > button:hover .MuiAvatar-root': {
+      '& > button:hover .MuiAvatar-root, & > a:hover .MuiAvatar-root': {
         backgroundColor: theme.palette.common.white,
+      },
+
+      '& > a:focus': {
+        outline: 'none',
       },
     }
   ),
@@ -98,11 +109,12 @@ const Task = styled(Box, {
 const SetupCardTaskCta = styled(Box, {
   name: 'WmeTaskCta',
   slot: 'Root',
-})<BoxProps>(() => ({
+})<BoxProps>(({ theme }) => ({
   display: 'flex',
   alignItems: 'center',
   marginLeft: 'auto',
   flex: '0 0 auto',
+  color: theme.palette.text.primary,
 }));
 
 const CtaAction = styled(Typography, {
@@ -122,9 +134,41 @@ const CtaAction = styled(Typography, {
   },
 }));
 
+const CtaActionButton = styled(Button, {
+  name: 'WmeTaskCta',
+  slot: 'Button',
+})<ButtonProps>(({ theme }) => ({
+  marginLeft: 'auto',
+  flex: '0 0 auto',
+
+  '&:hover': {
+    color: theme.palette.common.white,
+  },
+}));
+
+const TaskActionArea = styled(CardActionArea)<TaskActionAreaProps>(({ theme }) => ({
+  '&.Mui-focusVisible': {
+    boxShadow: 'none',
+    outline: 'none',
+  },
+  '& .MuiCardActionArea-focusHighlight': {
+    backgroundColor: theme.palette.grey[600],
+  },
+}));
+
 const SetupCardTask: React.FC<SetupCardProps> = (props) => {
   const {
-    title, intro, button, avatarProps, variant, taskCta, onClick, children, disabled = false,
+    id,
+    url = '',
+    title,
+    intro,
+    button,
+    avatarProps,
+    variant,
+    taskCta,
+    onClick,
+    children,
+    disabled = false,
   } = props;
   const variantType = variant === 'action' ? 'action' : 'task';
 
@@ -134,7 +178,9 @@ const SetupCardTask: React.FC<SetupCardProps> = (props) => {
         condition={variantType === 'task'}
         wrapper={
           (child: React.ReactNode) => (
-            <CardActionArea onClick={onClick} disabled={disabled}>{child}</CardActionArea>
+            <TaskActionArea onClick={onClick} disabled={disabled} href={url}>
+              {child}
+            </TaskActionArea>
           )
         }
       >
@@ -145,15 +191,15 @@ const SetupCardTask: React.FC<SetupCardProps> = (props) => {
           {children}
         </Box>
         {variantType === 'action' ? (
-          <Button
+          <CtaActionButton
             disabled={button?.disabled || disabled}
             variant="contained"
             href={button?.url}
             onClick={onClick}
-            sx={{ marginLeft: 'auto', flex: '0 0 auto' }}
+            sx={{ backgroundColor: button?.backgroundColor ? button.backgroundColor : null }}
           >
             {button?.label}
-          </Button>
+          </CtaActionButton>
         )
           : (
             <SetupCardTaskCta className={SetupCardTaskCta.displayName}>

--- a/src/components/setup-card-task/setup-card-task.tsx
+++ b/src/components/setup-card-task/setup-card-task.tsx
@@ -178,7 +178,12 @@ const SetupCardTask: React.FC<SetupCardProps> = (props) => {
         condition={variantType === 'task'}
         wrapper={
           (child: React.ReactNode) => (
-            <TaskActionArea onClick={onClick} disabled={disabled} href={url}>
+            <TaskActionArea
+              className={TaskActionArea.displayName}
+              onClick={onClick}
+              disabled={disabled}
+              href={url}
+            >
               {child}
             </TaskActionArea>
           )
@@ -192,6 +197,7 @@ const SetupCardTask: React.FC<SetupCardProps> = (props) => {
         </Box>
         {variantType === 'action' ? (
           <CtaActionButton
+            className={CtaActionButton.displayName}
             disabled={button?.disabled || disabled}
             variant="contained"
             href={button?.url}


### PR DESCRIPTION
While implementing this component in StoreBuilder I discovered some shortcomings in this component. This PR addresses uniformity issues in styles and allows for the `TaskActionArea` prop to be also be link-able.