### PR TITLE
Framework implementation updates

### DIFF
--- a/src/components/select-input/select-input.tsx
+++ b/src/components/select-input/select-input.tsx
@@ -60,13 +60,13 @@ const SelectInput: React.FC<SelectInputProps> = ({
     },
   };
 
-  const childrenWithIcons = children
-    && (children as React.ReactElement[])?.map((child) => {
-      if (child && (value as string[])?.includes(child.props.value)) {
+  const childrenWithIcons = Array.isArray(children) && Array.isArray(value) ?
+    (children as React.ReactElement[])?.map((child) => {
+      if (child && value.includes(child.props.value)) {
         return React.cloneElement(child, { icon: <CheckIcon /> });
       }
       return child;
-    });
+    }) : children;
 
   return (
     <StyledSelectInput
@@ -86,6 +86,7 @@ const SelectInput: React.FC<SelectInputProps> = ({
           </span>
         );
       }}
+      value={value}
       {...props}
     >
       {childrenWithIcons}

--- a/src/components/text-input/text-input.tsx
+++ b/src/components/text-input/text-input.tsx
@@ -18,7 +18,7 @@ const StyledTextInput = styled(InputBase, {
     padding: '5px 6px',
     paddingRight: '35px',
     position: 'relative',
-    width: '415px',
+    width: '100%',
     '&:focus': {
       borderColor: theme.palette.text.primary,
     },

--- a/src/components/wizard-section-title/wizard-section-title.tsx
+++ b/src/components/wizard-section-title/wizard-section-title.tsx
@@ -9,15 +9,21 @@ import { pxToRem } from '../../utils';
 
 interface WizardSectionTitleProps extends BoxProps {
   heading?: string;
+  headingComponent?: React.ElementType;
   headingVariant?: 'h1' | 'h2' | 'h3' | 'h4';
   copy?: string;
   copyAlign?: 'center' | 'left';
+  copyVariant?: 'h1' | 'h2' | 'h3' | 'h4';
   iconSrc?: string;
   iconAlt?: string;
   iconWidth?: string;
   width?: string;
   bookend?: boolean;
 }
+
+type StyledTypography = {
+  component?: React.ElementType;
+};
 
 const WizardSectionTitleContainer = styled(Box, {
   name: 'WmeWizardSectionTitle',
@@ -32,14 +38,14 @@ const WizardSectionTitleContainer = styled(Box, {
 const Heading = styled(Typography, {
   name: 'WmeWizardSectionTitle',
   slot: 'Heading',
-})(({ theme }) => ({
+})<StyledTypography>(({ theme }) => ({
   marginBottom: theme.spacing(2),
 }));
 
 const Copy = styled(Typography, {
   name: 'WmeWizardSectionTitle',
   slot: 'Copy',
-})(() => ({
+})<StyledTypography>(() => ({
   lineHeight: pxToRem(24),
 }));
 
@@ -53,9 +59,11 @@ const IconContainer = styled(Box, {
 const WizardSectionTitle: React.FC<WizardSectionTitleProps> = (props) => {
   const {
     heading,
+    headingComponent,
     headingVariant,
     copy,
     copyAlign,
+    copyVariant,
     iconSrc,
     iconAlt,
     iconWidth = 'auto',
@@ -73,22 +81,29 @@ const WizardSectionTitle: React.FC<WizardSectionTitleProps> = (props) => {
       bookend={bookend}
       {...rest}
     >
-      {
-        iconSrc
-        && (
-          <IconContainer className={IconContainer.displayName}>
-            <img src={iconSrc} alt={iconAlt} width={iconWidth} />
-          </IconContainer>
-        )
-      }
-      <Heading className={Heading.displayName} variant={headingVariant || 'h2'}>{heading}</Heading>
-      <Copy
-        variant="body1"
-        align={copyAlign && !bookend ? copyAlign : 'inherit'}
-        className={Copy.displayName}
-      >
-        {copy}
-      </Copy>
+      {iconSrc && (
+        <IconContainer className={IconContainer.displayName}>
+          <img src={iconSrc} alt={iconAlt} width={iconWidth} />
+        </IconContainer>
+      )}
+      {heading && (
+        <Heading
+          className={Heading.displayName}
+          component={headingComponent || 'h2'}
+          variant={headingVariant}
+        >
+          {heading}
+        </Heading>
+      )}
+      {copy && (
+        <Copy
+          align={copyAlign && !bookend ? copyAlign : 'inherit'}
+          className={Copy.displayName}
+          variant={copyVariant || 'body1'}
+        >
+          {copy}
+        </Copy>
+      )}
     </WizardSectionTitleContainer>
   );
 };


### PR DESCRIPTION
- [Fix 'SelectInput' `children` rendering logic and add `value` prop](https://github.com/moderntribe/wme/commit/2db7b07f15a934ba5af3e70bf4dcef679a68ba98)
- [Set 'TextInput' width to `100%`](https://github.com/moderntribe/wme/commit/4f99a5f06419f103ba6a69111d6995884d0b861a)
- [Add 'headingComponent' and 'copyVariant' props to 'WizardSectionTitle'](https://github.com/moderntribe/wme/commit/c889aac31086653059d2e740c714850c7fa6b489)