### PR TITLE
Update file upload component logic

### DIFF
--- a/src/components/file-upload-delete/index.ts
+++ b/src/components/file-upload-delete/index.ts
@@ -1,2 +1,0 @@
-export { default } from './file-upload-delete';
-export * from './file-upload-delete';

--- a/src/components/file-upload-header/file-upload-header.tsx
+++ b/src/components/file-upload-header/file-upload-header.tsx
@@ -29,15 +29,15 @@ const StyledButton = styled(ButtonUnstyled, {
 }));
 
 export interface FileUploadHeaderProps {
+  button?: React.ReactElement;
   buttonText?: string;
-  fileUploaded?: boolean;
   labelText?: string;
   onRemove?: React.MouseEventHandler<HTMLButtonElement>;
 }
 
 const FileUploadHeader: React.FC<FileUploadHeaderProps> = ({
+  button,
   buttonText,
-  fileUploaded,
   labelText,
   onRemove,
   ...props
@@ -47,9 +47,7 @@ const FileUploadHeader: React.FC<FileUploadHeaderProps> = ({
     {...props}
   >
     {labelText && <InputTitle>{labelText}</InputTitle>}
-    {fileUploaded && (
-      <StyledButton onClick={onRemove}>{buttonText}</StyledButton>
-    )}
+    {button || <StyledButton onClick={onRemove}>{buttonText}</StyledButton>}
   </StyledFileUploadHeader>
 );
 

--- a/src/components/file-upload-remove/file-upload-remove.stories.mdx
+++ b/src/components/file-upload-remove/file-upload-remove.stories.mdx
@@ -7,11 +7,11 @@ import { FileUploadRemove } from "..";
   argTypes={{
     buttonText: {
       control: "text",
-      description: "Text to display inside upload button",
+      description: "Text to display inside remove button",
     },
-    helperText: {
+    cancelText: {
       control: "text",
-      description: "Text to display under upload button",
+      description: "Text to display inside cancel button",
     },
     onCancel: { 
       description: 'Callback fired when the cancel button is clicked.', 
@@ -63,7 +63,7 @@ export default MyFileUploadRemove;
   <Story
     name="Base"
     args={{
-      helperText: "Are you sure you want to remove this file?",
+      cancelText: "Nevermind",
     }}
   >
     {Template.bind({})}

--- a/src/components/file-upload-remove/file-upload-remove.stories.mdx
+++ b/src/components/file-upload-remove/file-upload-remove.stories.mdx
@@ -1,9 +1,9 @@
 import { ArgsTable, Story, Canvas, Meta } from "@storybook/addon-docs";
-import { FileUploadDelete } from "..";
+import { FileUploadRemove } from "..";
 
 <Meta
-  title="Forms/FileUploadDelete"
-  component={FileUploadDelete}
+  title="Forms/FileUploadRemove"
+  component={FileUploadRemove}
   argTypes={{
     buttonText: {
       control: "text",
@@ -21,8 +21,8 @@ import { FileUploadDelete } from "..";
         }, 
       }
     },
-    onDelete: { 
-      description: 'Callback fired when the delete button is clicked.', 
+    onRemove: { 
+      description: 'Callback fired when the remove file button is clicked.', 
       table: { 
         type: { 
           summary: '(e: React.MouseEvent<HTMLButtonElement>) => void', 
@@ -32,11 +32,11 @@ import { FileUploadDelete } from "..";
   }}
 />
 
-export const Template = (args) => <FileUploadDelete {...args} />;
+export const Template = (args) => <FileUploadRemove {...args} />;
 
-# FileUploadDelete
+# FileUploadRemove
 
-Composes `Button`, and `FormHelperText` to create a single, re-usable "FileUploadDelete" component.
+Composes `Button`, and `FormHelperText` to create a single, re-usable "FileUploadRemove" component.
 
 **_Note:_** Any additional props passed to this component will be passed to <a href="https://mui.com/material-ui/api/box/" target="_blank">MUI's Box</a>, so you can use any prop provided there.
 
@@ -48,13 +48,13 @@ Composes `Button`, and `FormHelperText` to create a single, re-usable "FileUploa
 
 ```
 import React, { useState } from 'react';
-import { FileUploadDelete } from '@moderntribe/wme';
+import { FileUploadRemove } from '@moderntribe/wme';
 
-export const MyFileUploadDelete = (props) => (
-  <FileUploadDelete {...props} />
+export const MyFileUploadRemove = (props) => (
+  <FileUploadRemove {...props} />
 );
 
-export default MyFileUploadDelete;
+export default MyFileUploadRemove;
 ```
 
 ## Canvas

--- a/src/components/file-upload-remove/file-upload-remove.tsx
+++ b/src/components/file-upload-remove/file-upload-remove.tsx
@@ -3,15 +3,15 @@ import { Box, styled } from '@mui/material';
 import DeleteIcon from '@mui/icons-material/Delete';
 import { Button, InputHelperText } from '..';
 
-export interface FileUploadDeleteProps {
+export interface FileUploadRemoveProps {
   buttonText?: string;
   helperText?: string;
   onCancel?: React.MouseEventHandler<HTMLParagraphElement>;
-  onDelete?: React.MouseEventHandler<HTMLButtonElement>;
+  onRemove?: React.MouseEventHandler<HTMLButtonElement>;
 }
 
-const StyledFileUploadDelete = styled(Box, {
-  name: 'WmeFileUploadDelete',
+const StyledFileUploadRemove = styled(Box, {
+  name: 'WmeFileUploadRemove',
   slot: 'Root',
 })({
   alignItems: 'center',
@@ -20,20 +20,20 @@ const StyledFileUploadDelete = styled(Box, {
   justifyContent: 'center',
 });
 
-const FileUploadDelete: React.FC<FileUploadDeleteProps> = ({
+const FileUploadRemove: React.FC<FileUploadRemoveProps> = ({
   buttonText,
   helperText,
   onCancel,
-  onDelete,
+  onRemove,
   ...props
 }) => (
-  <StyledFileUploadDelete
-    className={StyledFileUploadDelete.displayName}
+  <StyledFileUploadRemove
+    className={StyledFileUploadRemove.displayName}
     {...props}
   >
     <Button
       color="error"
-      onClick={onDelete}
+      onClick={onRemove}
       startIcon={<DeleteIcon />}
       variant="contained"
     >
@@ -44,7 +44,7 @@ const FileUploadDelete: React.FC<FileUploadDeleteProps> = ({
         {helperText}
       </InputHelperText>
     )}
-  </StyledFileUploadDelete>
+  </StyledFileUploadRemove>
 );
 
-export default FileUploadDelete;
+export default FileUploadRemove;

--- a/src/components/file-upload-remove/file-upload-remove.tsx
+++ b/src/components/file-upload-remove/file-upload-remove.tsx
@@ -5,8 +5,8 @@ import { Button, InputHelperText } from '..';
 
 export interface FileUploadRemoveProps {
   buttonText?: string;
-  helperText?: string;
-  onCancel?: React.MouseEventHandler<HTMLParagraphElement>;
+  cancelText?: string;
+  onCancel?: React.MouseEventHandler<HTMLButtonElement>;
   onRemove?: React.MouseEventHandler<HTMLButtonElement>;
 }
 
@@ -16,13 +16,12 @@ const StyledFileUploadRemove = styled(Box, {
 })({
   alignItems: 'center',
   display: 'flex',
-  flexDirection: 'column',
   justifyContent: 'center',
 });
 
 const FileUploadRemove: React.FC<FileUploadRemoveProps> = ({
   buttonText,
-  helperText,
+  cancelText,
   onCancel,
   onRemove,
   ...props
@@ -39,10 +38,10 @@ const FileUploadRemove: React.FC<FileUploadRemoveProps> = ({
     >
       {buttonText || 'Delete'}
     </Button>
-    {helperText && (
-      <InputHelperText onClick={onCancel} sx={{ cursor: 'pointer' }}>
-        {helperText}
-      </InputHelperText>
+    {cancelText && (
+      <Button onClick={onCancel} sx={{ color: 'text.primary', ml: 1 }}>
+        {cancelText}
+      </Button>
     )}
   </StyledFileUploadRemove>
 );

--- a/src/components/file-upload-remove/index.ts
+++ b/src/components/file-upload-remove/index.ts
@@ -1,0 +1,2 @@
+export { default } from './file-upload-remove';
+export * from './file-upload-remove';

--- a/src/components/file-upload-select/file-upload-select.tsx
+++ b/src/components/file-upload-select/file-upload-select.tsx
@@ -1,5 +1,10 @@
 import React from 'react';
-import { Box, styled } from '@mui/material';
+import {
+  Box,
+  ButtonProps,
+  InputBaseProps,
+  styled
+} from '@mui/material';
 import { visuallyHidden } from '@mui/utils';
 import AddIcon from '@mui/icons-material/Add';
 import { Button, FileInput, FormHelperText } from '..';
@@ -17,20 +22,24 @@ const StyledFileUploadSelect = styled(Box, {
 
 export interface FileUploadSelectProps {
   buttonText?: string;
+  buttonProps?: ButtonProps;
   helperText?: string;
+  inputProps?: InputBaseProps;
 }
 
 const FileUploadSelect: React.FC<FileUploadSelectProps> = ({
   buttonText,
+  buttonProps,
   helperText,
+  inputProps,
   ...props
 }) => (
   <StyledFileUploadSelect
     className={StyledFileUploadSelect.displayName}
     {...props}
   >
-    <FileInput />
-    <Button color="primary" startIcon={<AddIcon />} variant="contained">
+    <FileInput {...inputProps} />
+    <Button color="primary" startIcon={<AddIcon />} variant="contained" {...buttonProps}>
       {buttonText || 'Add File'}
     </Button>
     {helperText && <FormHelperText>{helperText}</FormHelperText>}

--- a/src/components/file-upload/file-upload.stories.mdx
+++ b/src/components/file-upload/file-upload.stories.mdx
@@ -34,7 +34,7 @@ export const Template = (args) => {
         onRemove: handleShowRemove,
       }}
       removeProps={{
-        helperText: "Cancel",
+        cancelText: "Cancel",
         onCancel: handleHideRemove,
         onRemove: handleRemoveFile,
       }}

--- a/src/components/file-upload/file-upload.stories.mdx
+++ b/src/components/file-upload/file-upload.stories.mdx
@@ -23,7 +23,7 @@ export const Template = (args) => {
   const handleHideRemove = () => {
     setShowActions(false);
   };
-  const handleDeleteFile = () => {
+  const handleRemoveFile = () => {
     setUploaded(false);
   };
   return (
@@ -36,7 +36,7 @@ export const Template = (args) => {
       removeProps={{
         helperText: "Cancel",
         onCancel: handleHideRemove,
-        onDelete: handleDeleteFile,
+        onRemove: handleRemoveFile,
       }}
       selectProps={{
         buttonText: "Add File",
@@ -51,7 +51,7 @@ export const Template = (args) => {
 
 # FileUpload
 
-Composes `FileUploadHeader`, `FileUploadSelect`, `FileUploadPreview` and `FileUploadDelete` to create a single, re-usable "FileUpload" component.
+Composes `FileUploadHeader`, `FileUploadSelect`, `FileUploadPreview` and `FileUploadRemove` to create a single, re-usable "FileUpload" component.
 
 **_Note:_** Any additional props passed to this component will be passed to <a href="https://mui.com/material-ui/api/box/" target="_blank">MUI's Box</a>, so you can use any prop provided there.
 

--- a/src/components/file-upload/file-upload.tsx
+++ b/src/components/file-upload/file-upload.tsx
@@ -33,9 +33,7 @@ interface FileUploadProps extends BoxProps {
 const StyledFileUpload = styled(Box, {
   name: 'WmeFileUpload',
   slot: 'Root',
-})({
-  width: 415,
-});
+})({});
 
 const StyledFileUploadBody = styled(Box, {
   name: 'WmeFileUploadBody',
@@ -50,7 +48,6 @@ const StyledFileUploadBody = styled(Box, {
   flexDirection: 'column',
   justifyContent: 'center',
   minHeight: 106,
-  width: 415,
   '& .MuiInputBase-input': visuallyHidden,
 }));
 

--- a/src/components/file-upload/file-upload.tsx
+++ b/src/components/file-upload/file-upload.tsx
@@ -8,8 +8,8 @@ import {
   FileUploadHeaderProps,
   FileUploadPreview,
   FileUploadPreviewProps,
-  FileUploadDelete,
-  FileUploadDeleteProps,
+  FileUploadRemove,
+  FileUploadRemoveProps,
   FileUploadSelect,
   FileUploadSelectProps,
 } from '..';
@@ -24,7 +24,7 @@ interface FileUploadProps extends BoxProps {
   uploaded?: boolean;
   preview?: React.ReactElement;
   previewProps?: FileUploadPreviewProps;
-  removeProps?: FileUploadDeleteProps;
+  removeProps?: FileUploadRemoveProps;
   select?: React.ReactElement;
   selectProps?: FileUploadSelectProps;
   showActions?: boolean;
@@ -69,9 +69,9 @@ const FileUpload: React.FC<FileUploadProps> = ({
 }) => {
   const formControlContext = useFormControlUnstyledContext();
 
-  // Use `FileUploadDelete` if no override is preset
+  // Use `FileUploadRemove` if no override is preset
   if (!action) {
-    action = <FileUploadDelete {...removeProps} />;
+    action = <FileUploadRemove {...removeProps} />;
   }
 
   // Use `FileUploadHeader` if no override is preset

--- a/src/components/file-upload/file-upload.tsx
+++ b/src/components/file-upload/file-upload.tsx
@@ -77,7 +77,7 @@ const FileUpload: React.FC<FileUploadProps> = ({
 
   // Use `FileUploadHeader` if no override is preset
   if (!header) {
-    header = <FileUploadHeader fileUploaded={uploaded} {...headerProps} />;
+    header = <FileUploadHeader {...headerProps} />;
   }
 
   // Use `File` if no override is preset

--- a/src/components/file-upload/file-upload.tsx
+++ b/src/components/file-upload/file-upload.tsx
@@ -17,6 +17,7 @@ import {
 interface FileUploadProps extends BoxProps {
   action?: React.ReactElement;
   actionProps?: any;
+  alert?: React.ReactElement;
   error?: boolean;
   header?: React.ReactElement;
   headerProps?: FileUploadHeaderProps;
@@ -56,6 +57,7 @@ const StyledFileUploadBody = styled(Box, {
 const FileUpload: React.FC<FileUploadProps> = ({
   action,
   actionProps,
+  alert,
   error,
   header,
   headerProps,
@@ -97,6 +99,7 @@ const FileUpload: React.FC<FileUploadProps> = ({
     <StyledFileUpload className={StyledFileUpload.displayName} {...props}>
       {header}
       <StyledFileUploadBody error={error || formControlContext?.error}>
+        {alert}
         {error || !uploaded ? select : fileView}
       </StyledFileUploadBody>
     </StyledFileUpload>

--- a/src/components/file-upload/file-upload.tsx
+++ b/src/components/file-upload/file-upload.tsx
@@ -90,14 +90,14 @@ const FileUpload: React.FC<FileUploadProps> = ({
   }
 
   // Toggle "action" display logic
-  const fileView = showActions ? action : preview;
+  const view = showActions ? action : preview;
 
   return (
     <StyledFileUpload className={StyledFileUpload.displayName} {...props}>
       {header}
       <StyledFileUploadBody error={error || formControlContext?.error}>
         {alert}
-        {error || !uploaded ? select : fileView}
+        {error || !uploaded ? select : view}
       </StyledFileUploadBody>
     </StyledFileUpload>
   );

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -100,8 +100,8 @@ export * from './file-input';
 export { default as FileUploadSelect } from './file-upload-select';
 export * from './file-upload-select';
 
-export { default as FileUploadDelete } from './file-upload-delete';
-export * from './file-upload-delete';
+export { default as FileUploadRemove } from './file-upload-remove';
+export * from './file-upload-remove';
 
 export { default as FileUploadPreview } from './file-upload-preview';
 export * from './file-upload-preview';


### PR DESCRIPTION
## Summary
- Updates `FileUpload` component to account for `StoreBuilder FileUpload` component modifications. 
- Renames `FileUploadDelete` to `FileUploadRemove` because semantically we are always "removing a file", but not always "deleting a file".

## Commits
- [Allow 'FileUploadHeader' button to be overwritten](https://github.com/moderntribe/wme/commit/ab60ca9555c9bb0647ee73faa08faba2856e88a2)
- [Allow 'FileUploadSelect' to receive 'button' and 'input' props](https://github.com/moderntribe/wme/commit/b1e1fe53526980219afa11fd76d854a24e5bef37)
- [Add 'alert' to 'FileUpload' component](https://github.com/moderntribe/wme/commit/c172d37c3fa8b87bf0b1324a1492fbb8e9f317cc)
- [Remove 'FileUpload' width styles](https://github.com/moderntribe/wme/commit/6516d865c5ba49947bd6bdb625a4ec9ce0ade5c5)
- [Rename 'fileView' to 'view'](https://github.com/moderntribe/wme/commit/74c3c4b095dc2b31e488c8695b24a2d3d7de1cad)
- [Rename 'FileUploadDelete' to 'FileUploadRemove'](https://github.com/moderntribe/wme/commit/c9a96adbce8183688b467970d604ad8bed4f90a7)
- [Convert 'FileUploadRemove' helper text to button](https://github.com/moderntribe/wme/commit/ae1bcee34938f4ceb97c1cbc1793f38d720d810d)