### PR TITLE
Fix FileUpload select file and show delete logic

### DIFF
--- a/src/components/file-upload-header/file-upload-header.tsx
+++ b/src/components/file-upload-header/file-upload-header.tsx
@@ -33,6 +33,7 @@ export interface FileUploadHeaderProps {
   buttonText?: string;
   labelText?: string;
   onRemove?: React.MouseEventHandler<HTMLButtonElement>;
+  showButton?: boolean;
 }
 
 const FileUploadHeader: React.FC<FileUploadHeaderProps> = ({
@@ -40,6 +41,7 @@ const FileUploadHeader: React.FC<FileUploadHeaderProps> = ({
   buttonText,
   labelText,
   onRemove,
+  showButton,
   ...props
 }) => (
   <StyledFileUploadHeader
@@ -47,7 +49,7 @@ const FileUploadHeader: React.FC<FileUploadHeaderProps> = ({
     {...props}
   >
     {labelText && <InputTitle>{labelText}</InputTitle>}
-    {button || <StyledButton onClick={onRemove}>{buttonText}</StyledButton>}
+    {showButton && button || <StyledButton onClick={onRemove}>{buttonText}</StyledButton>}
   </StyledFileUploadHeader>
 );
 

--- a/src/components/file-upload-select/file-upload-select.tsx
+++ b/src/components/file-upload-select/file-upload-select.tsx
@@ -38,10 +38,12 @@ const FileUploadSelect: React.FC<FileUploadSelectProps> = ({
     className={StyledFileUploadSelect.displayName}
     {...props}
   >
-    <FileInput {...inputProps} />
-    <Button color="primary" startIcon={<AddIcon />} variant="contained" {...buttonProps}>
-      {buttonText || 'Add File'}
-    </Button>
+    <label htmlFor={inputProps?.id}>
+      <FileInput {...inputProps} />
+      <Button color="primary" startIcon={<AddIcon />} variant="contained" {...buttonProps}>
+        {buttonText || 'Add File'}
+      </Button>
+    </label>
     {helperText && <FormHelperText>{helperText}</FormHelperText>}
   </StyledFileUploadSelect>
 );

--- a/src/components/file-upload/file-upload.tsx
+++ b/src/components/file-upload/file-upload.tsx
@@ -76,7 +76,7 @@ const FileUpload: React.FC<FileUploadProps> = ({
 
   // Use `FileUploadHeader` if no override is preset
   if (!header) {
-    header = <FileUploadHeader {...headerProps} />;
+    header = <FileUploadHeader showButton={uploaded} {...headerProps} />;
   }
 
   // Use `File` if no override is preset


### PR DESCRIPTION
- [Wrap FileUpload input and button with label so clicking button opens file selection wndow](https://github.com/moderntribe/wme/commit/748ac676943a68882c5c6daea022345e59f91397)
- [Add 'showButton' prop to FileUploadHeader to prevent showing "delete" button when file isn't uploaded](https://github.com/moderntribe/wme/commit/58982d86fff781aff8231ac3626bf433e671f7e3)