### PR TITLE
Fix Styled classNames issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@moderntribe/wme",
-  "version": "0.1.20",
+  "version": "0.1.21",
   "private": false,
   "author": "Moderntribe Incubator Team",
   "description": "Components and hooks to build the best UX/UI admin wizards",

--- a/src/components/button/button.tsx
+++ b/src/components/button/button.tsx
@@ -39,7 +39,7 @@ const StyledButton = styled(MuiButton, {
 }));
 
 const Button: React.FC<ButtonProps> = (props) => (
-  <StyledButton className={StyledButton.displayName} {...props} />
+  <StyledButton className="WmeButton-root" {...props} />
 );
 
 export default Button;

--- a/src/components/checkbox-input/checkbox-input.tsx
+++ b/src/components/checkbox-input/checkbox-input.tsx
@@ -24,7 +24,7 @@ const StyledCheckbox = styled(MuiCheckbox, {
 }));
 
 const CheckboxInput: React.FC<CheckboxProps> = (props) => (
-  <StyledCheckbox className={StyledCheckbox.displayName} {...props} />
+  <StyledCheckbox className="WmeCheckboxInput-root" {...props} />
 );
 
 export default CheckboxInput;

--- a/src/components/chip/chip.tsx
+++ b/src/components/chip/chip.tsx
@@ -29,5 +29,5 @@ const StyledChip = styled(MuiChip)<ChipProps>(({ color, size, theme }) => ({
 }));
 
 export default function Chip(props: ChipProps) {
-  return <StyledChip className={StyledChip.displayName} {...props} />;
+  return <StyledChip className="WmeChip-root" {...props} />;
 }

--- a/src/components/device-selection/device-selection.tsx
+++ b/src/components/device-selection/device-selection.tsx
@@ -38,7 +38,7 @@ const DeviceSelection: React.FC<DeviceSelectionProps> = (props) => {
   const { devices } = props;
 
   return (
-    <DeviceSelectionContainer>
+    <DeviceSelectionContainer className="WmeDeviceSelectionContainer-root">
       { devices.map((device, key) => {
         const DeviceName:any = devices[key].icon;
         return (

--- a/src/components/error-text/error-text.tsx
+++ b/src/components/error-text/error-text.tsx
@@ -16,7 +16,7 @@ const ErrorText: React.FC<TypographyProps> = (props) => {
   const { displayName } = StyledText;
 
   return (
-    <StyledText className={displayName} {...props}>
+    <StyledText className="WmeErrorText-root" {...props}>
       {children}
     </StyledText>
   );

--- a/src/components/exit-button/exit-button.tsx
+++ b/src/components/exit-button/exit-button.tsx
@@ -23,7 +23,7 @@ const ExitButton: React.FC<ExitButtonProps> = (props) => {
   const { children, onClick, ...rest } = props;
 
   return (
-    <ExitButtonContainer className={ExitButtonContainer.displayName} {...rest}>
+    <ExitButtonContainer className="WmeExitButton-root" {...rest}>
       <Button onClick={onClick}>
         {children}
         <Logout sx={{ ml: 1 }} />

--- a/src/components/file-input/file-input.tsx
+++ b/src/components/file-input/file-input.tsx
@@ -9,7 +9,7 @@ const StyledFileInput = styled(InputBase, {
 const FileInput: React.FC<InputBaseProps> = (props) => (
   <StyledFileInput
     type="file"
-    className={StyledFileInput.displayName}
+    className="WmeFileInput-root"
     {...props}
   />
 );

--- a/src/components/file-upload-header/file-upload-header.tsx
+++ b/src/components/file-upload-header/file-upload-header.tsx
@@ -45,7 +45,7 @@ const FileUploadHeader: React.FC<FileUploadHeaderProps> = ({
   ...props
 }) => (
   <StyledFileUploadHeader
-    className={StyledFileUploadHeader.displayName}
+    className="WmeFileUploadHeader-root"
     {...props}
   >
     {labelText && <InputTitle>{labelText}</InputTitle>}

--- a/src/components/file-upload-preview/file-upload-preview.tsx
+++ b/src/components/file-upload-preview/file-upload-preview.tsx
@@ -21,7 +21,7 @@ const FileUploadPreview: React.FC<FileUploadPreviewProps> = ({
   ...props
 }) => (
   <StyledFileUploadPreview
-    className={StyledFileUploadPreview.displayName}
+    className="WmeFilePreview-root"
     {...props}
   >
     {imagePath ? (

--- a/src/components/file-upload-remove/file-upload-remove.tsx
+++ b/src/components/file-upload-remove/file-upload-remove.tsx
@@ -27,7 +27,7 @@ const FileUploadRemove: React.FC<FileUploadRemoveProps> = ({
   ...props
 }) => (
   <StyledFileUploadRemove
-    className={StyledFileUploadRemove.displayName}
+    className="WmeFileUploadRemove-root"
     {...props}
   >
     <Button

--- a/src/components/file-upload-select/file-upload-select.tsx
+++ b/src/components/file-upload-select/file-upload-select.tsx
@@ -35,7 +35,7 @@ const FileUploadSelect: React.FC<FileUploadSelectProps> = ({
   ...props
 }) => (
   <StyledFileUploadSelect
-    className={StyledFileUploadSelect.displayName}
+    className="WmeFileUploadSelect-root"
     {...props}
   >
     <label htmlFor={inputProps?.id}>

--- a/src/components/file-upload/file-upload.tsx
+++ b/src/components/file-upload/file-upload.tsx
@@ -93,7 +93,7 @@ const FileUpload: React.FC<FileUploadProps> = ({
   const view = showActions ? action : preview;
 
   return (
-    <StyledFileUpload className={StyledFileUpload.displayName} {...props}>
+    <StyledFileUpload className="WmeFileUpload-root" {...props}>
       {header}
       <StyledFileUploadBody error={error || formControlContext?.error}>
         {alert}

--- a/src/components/form-control-label/form-control-label.tsx
+++ b/src/components/form-control-label/form-control-label.tsx
@@ -24,7 +24,7 @@ const FormControlLabel: React.FC<FormControlProps> = (props) => {
   const { displayName } = StyledFormControlLabel;
 
   return (
-    <StyledFormControlLabel className={displayName} {...rest}>
+    <StyledFormControlLabel className="WmeFormControlLabel-root" {...rest}>
       {children}
     </StyledFormControlLabel>
   );

--- a/src/components/form-field-control/form-field-control.tsx
+++ b/src/components/form-field-control/form-field-control.tsx
@@ -11,7 +11,7 @@ const FormFieldControl: React.FC<FormControlUnstyledProps> = ({
   children,
   ...props
 }) => (
-  <StyledFormFieldControl className={StyledFormFieldControl.displayName} {...props}>
+  <StyledFormFieldControl className="WmeFormFieldControl-root" {...props}>
     {children}
   </StyledFormFieldControl>
 );

--- a/src/components/form-field-label/form-field-label.tsx
+++ b/src/components/form-field-label/form-field-label.tsx
@@ -16,7 +16,7 @@ const FormFieldLabel: React.FC<PropsWithChildren<InputLabelProps>> = ({
   children,
   ...props
 }) => (
-  <StyledFormFieldLabel className={StyledFormFieldLabel.displayName} {...props}>
+  <StyledFormFieldLabel className="WmeFormFieldLabel-root" {...props}>
     {children}
   </StyledFormFieldLabel>
 );

--- a/src/components/form-field/form-field.tsx
+++ b/src/components/form-field/form-field.tsx
@@ -24,7 +24,7 @@ const FormField: React.FC<PropsWithChildren<FormFieldProps>> = ({
   label,
   ...props
 }) => (
-  <FormFieldControl {...props}>
+  <FormFieldControl className="WmeFormFieldControl-root" {...props}>
     {label && <FormFieldLabel>{label}</FormFieldLabel>}
     {field}
     {errorMessage && <InputError>{errorMessage}</InputError>}

--- a/src/components/form-helper-text/form-helper-text.tsx
+++ b/src/components/form-helper-text/form-helper-text.tsx
@@ -19,7 +19,7 @@ const FormHelperText: React.FC<FormHelperTextProps> = (props) => {
   const { displayName } = StyledFormHelperText;
 
   return (
-    <StyledFormHelperText className={displayName} {...props}>
+    <StyledFormHelperText className="WmeFormHelperText-root" {...props}>
       {children}
     </StyledFormHelperText>
   );

--- a/src/components/form/form.tsx
+++ b/src/components/form/form.tsx
@@ -9,7 +9,7 @@ const StyledForm = styled(Box, {
 const Form: React.FC<BoxProps> = ({ children, ...props }) => (
   <StyledForm
     autoComplete="off"
-    className={(StyledForm as any).displayName}
+    className="WmeForm-root"
     component="form"
     noValidate
     {...props}

--- a/src/components/input-error/input-error.tsx
+++ b/src/components/input-error/input-error.tsx
@@ -16,7 +16,7 @@ const InputError: React.FC<TypographyProps> = ({ children, ...props }) => {
 
   if (formControlContext?.error) {
     return (
-      <StyledInputError className={StyledInputError.displayName} {...props}>
+      <StyledInputError className="WmeInputError-root" {...props}>
         {children}
       </StyledInputError>
     );

--- a/src/components/input-helper-text/input-helper-text.tsx
+++ b/src/components/input-helper-text/input-helper-text.tsx
@@ -18,7 +18,7 @@ const InputHelperText: React.FC<PropsWithChildren<InputHelperTextProps>> = ({
   ...props
 }) => (
   <StyledInputHelperText
-    className={StyledInputHelperText.displayName}
+    className="WmeInputHelperText-root"
     {...props}
   >
     {children}

--- a/src/components/input-label/input-label.tsx
+++ b/src/components/input-label/input-label.tsx
@@ -13,7 +13,7 @@ const StyledInputLabel = styled(FormControlLabel, {
 }));
 
 const InputLabel: React.FC<FormControlLabelProps> = (props) => (
-  <StyledInputLabel className={StyledInputLabel.displayName} {...props} />
+  <StyledInputLabel className="WmeInputLabel-root" {...props} />
 );
 
 export default InputLabel;

--- a/src/components/input-title/input-title.tsx
+++ b/src/components/input-title/input-title.tsx
@@ -21,7 +21,7 @@ const InputTitle: React.FC<InputTitleProps> = (props) => {
   const { children } = props;
   const { displayName } = StyledInputTitle;
   return (
-    <StyledInputTitle className={displayName}>
+    <StyledInputTitle className="WmeInputTitle-root">
       {children}
     </StyledInputTitle>
   );

--- a/src/components/logo/logo.tsx
+++ b/src/components/logo/logo.tsx
@@ -25,7 +25,7 @@ const Logo: React.FC<LogoContainerProps> = (props) => {
   const { logoSrc, logoAlt, width } = props;
 
   return (
-    <LogoContainer className={LogoContainer.displayName} width={width}>
+    <LogoContainer className="WmeLogoContainer-root" width={width}>
       <img src={logoSrc} alt={logoAlt} />
     </LogoContainer>
   );

--- a/src/components/menu-item/menu-item.tsx
+++ b/src/components/menu-item/menu-item.tsx
@@ -34,7 +34,7 @@ const MenuItem: React.FC<WmeMenuItemProps> = (props) => {
   const { displayName } = StyledMenuItem;
 
   return (
-    <StyledMenuItem className={displayName} {...props}>
+    <StyledMenuItem className="WmeMenuItem-root" {...props}>
       {children}
       {icon
       && (

--- a/src/components/password-input/chip.tsx
+++ b/src/components/password-input/chip.tsx
@@ -22,7 +22,7 @@ const StyledChip = styled(MuiChip, {
 
 const Chip: React.FC<ChipProps> = ({ color, label, ...props }) => (
   <StyledChip
-    className={StyledChip.displayName}
+    className="WmePasswordInputChip-root"
     color={color}
     label={label}
     {...props}

--- a/src/components/password-input/end-adornment.tsx
+++ b/src/components/password-input/end-adornment.tsx
@@ -28,7 +28,7 @@ const EndAdornment: React.FC<EndAdornmentProps> = ({
   visible,
   ...props
 }) => (
-  <StyledInputAdornment className={StyledInputAdornment.displayName} {...props}>
+  <StyledInputAdornment className="WmePasswordInputAdornment-root" {...props}>
     {chip}
     <IconButton
       aria-label="toggle password visibility"

--- a/src/components/password-input/password-input.tsx
+++ b/src/components/password-input/password-input.tsx
@@ -33,7 +33,7 @@ const PasswordInput: React.FC<PasswordInputProps> = ({
 
   return (
     <StyledPasswordInput
-      className={StyledPasswordInput.displayName}
+      className="WmePasswordInput-root"
       endAdornment={(
         <EndAdornment
           chip={

--- a/src/components/progress-bar/progress-bar.tsx
+++ b/src/components/progress-bar/progress-bar.tsx
@@ -44,23 +44,23 @@ export default function ProgressBar(props: ProgressBarProps) {
   const { value, statusMessage } = props;
   const percentage = typeof value !== 'undefined' ? Math.round(value) : 0;
   return (
-    <StyledProgressBarWrapper className={StyledProgressBarWrapper.displayName}>
+    <StyledProgressBarWrapper className="WmeProgressBar-root">
       <StyledProgressBar
         aria-label="progress bar"
         variant="determinate"
-        className={StyledProgressBar.displayName}
+        className="WmeProgressBar-progress"
         {...props}
       />
       <StyledProgressBarPercentage
         variant="caption"
-        className={StyledProgressBarPercentage.displayName}
+        className="WmeProgressBar-percentage"
       >
         {`${percentage}%`}
       </StyledProgressBarPercentage>
       { statusMessage
       && (
         <StyledProgressBarStatusMessage
-          className={StyledProgressBarStatusMessage.displayName}
+          className="WmeProgressBar-status"
           variant="caption"
         >
             {statusMessage}

--- a/src/components/radio-group/radio-group.tsx
+++ b/src/components/radio-group/radio-group.tsx
@@ -27,7 +27,7 @@ const RadioGroup: React.FC<RadioGroupProps> = ({
 }) => (
   <StyledRadioGroup
     aria-labelledby={ariaLabelledby}
-    className={StyledRadioGroup.displayName}
+    className="WmeRadioGroup-root"
     {...props}
   >
     {children}

--- a/src/components/select-input/select-input.tsx
+++ b/src/components/select-input/select-input.tsx
@@ -70,7 +70,7 @@ const SelectInput: React.FC<SelectInputProps> = ({
 
   return (
     <StyledSelectInput
-      className={StyledSelectInput.displayName}
+      className="WmeSelectInput-root"
       displayEmpty
       error={formControlContext?.error}
       input={<OutlinedInput />}

--- a/src/components/setup-card-content/setup-card-content.tsx
+++ b/src/components/setup-card-content/setup-card-content.tsx
@@ -12,10 +12,9 @@ const SetupCardContentWrapper = styled(CardContent, {
 
 const SetupCardContent: React.FC<CardContentProps> = (props) => {
   const { children, ...rest } = props;
-  const { displayName } = SetupCardContentWrapper;
 
   return (
-    <SetupCardContentWrapper className={displayName} {...rest}>
+    <SetupCardContentWrapper className="WmeSetupCardContent-root" {...rest}>
       { children }
     </SetupCardContentWrapper>
   );

--- a/src/components/setup-card-footer/setup-card-footer.tsx
+++ b/src/components/setup-card-footer/setup-card-footer.tsx
@@ -37,10 +37,9 @@ const SetupCardFooterWrapper = styled(Box, {
 
 const SetupCardFooter: React.FC<BoxProps> = (props) => {
   const { children } = props;
-  const { displayName } = SetupCardFooterWrapper;
 
   return (
-    <SetupCardFooterWrapper className={displayName}>
+    <SetupCardFooterWrapper className="WmeSetupCardFooter-root">
       { children }
     </SetupCardFooterWrapper>
   );

--- a/src/components/setup-card-header/setup-card-header.tsx
+++ b/src/components/setup-card-header/setup-card-header.tsx
@@ -19,7 +19,5 @@ StyledSetupCardHeader.defaultProps = {
 };
 
 export default function SetupCardHeader(props: CardHeaderProps) {
-  const { displayName } = StyledSetupCardHeader;
-
-  return <StyledSetupCardHeader className={displayName} {...props} />;
+  return <StyledSetupCardHeader className="WmeSetupCardHeader-root" {...props} />;
 }

--- a/src/components/setup-card-info-row/setup-card-info-row.tsx
+++ b/src/components/setup-card-info-row/setup-card-info-row.tsx
@@ -73,7 +73,7 @@ const SetupCardInfoRow: React.FC<SetupCardInfoRowProps> = (props) => {
 
   return (
     <StyledSetupCardInfoRow
-      className={StyledSetupCardInfoRow.displayName}
+      className="WmeSetupCardInfoRow-root"
       hasIcon={!!icon}
       {...rest}
     >

--- a/src/components/setup-card-list-item/setup-card-list-item.tsx
+++ b/src/components/setup-card-list-item/setup-card-list-item.tsx
@@ -61,18 +61,18 @@ export default function SetupCardListItem(props: SetupCardListItemProps) {
         target={target}
         variant="body1"
         underline="none"
-        className={StyledSetupCardListItem.displayName}
+        className="WmeSetupCardListItem-root"
         {...linkProps}
       >
         { icon && (
           <StyledSetupCardIconWrapper
-            className={StyledSetupCardIconWrapper.displayName}
+            className="WmeSetupCardListItem-wmeIconWrapper"
           >
             {icon}
           </StyledSetupCardIconWrapper>
         )}
         <StyledSetupCardTextWrapper
-          className={StyledSetupCardTextWrapper.displayName}
+          className="WmeSetupCardListItem-wmeTextWrapper"
         >
           {title}
         </StyledSetupCardTextWrapper>

--- a/src/components/setup-card-list/setup-card-list.tsx
+++ b/src/components/setup-card-list/setup-card-list.tsx
@@ -14,5 +14,5 @@ const StyledSetupCardList = styled(List, {
 export default function SetupCardList(props: ListProps) {
   const { displayName } = StyledSetupCardList;
 
-  return <StyledSetupCardList className={displayName} dense disablePadding {...props} />;
+  return <StyledSetupCardList className="WmeSetupCardList-root" dense disablePadding {...props} />;
 }

--- a/src/components/setup-card-task-cta/setup-card-task-cta.tsx
+++ b/src/components/setup-card-task-cta/setup-card-task-cta.tsx
@@ -18,7 +18,7 @@ const StyledSetupCardTaskCta = styled(Button, {
 
 const SetupCardTaskCta: React.FC<SetupCardTaskCtaProps> = (props) => (
   <StyledSetupCardTaskCta
-    className={StyledSetupCardTaskCta.displayName}
+    className="WmeSetupCardTaskCta-root"
     {...props}
     fullWidth
     variant="outlined"

--- a/src/components/setup-card-task/setup-card-task.tsx
+++ b/src/components/setup-card-task/setup-card-task.tsx
@@ -7,7 +7,7 @@ import {
   Typography,
   TypographyProps,
 } from '@mui/material';
-import { ChevronRight, ConnectingAirportsOutlined } from '@mui/icons-material';
+import { ChevronRight } from '@mui/icons-material';
 import { styled } from '@mui/material/styles';
 
 import { ConditionalWrapper, pxToRem } from '../../utils';

--- a/src/components/setup-card-task/setup-card-task.tsx
+++ b/src/components/setup-card-task/setup-card-task.tsx
@@ -7,7 +7,7 @@ import {
   Typography,
   TypographyProps,
 } from '@mui/material';
-import { ChevronRight } from '@mui/icons-material';
+import { ChevronRight, ConnectingAirportsOutlined } from '@mui/icons-material';
 import { styled } from '@mui/material/styles';
 
 import { ConditionalWrapper, pxToRem } from '../../utils';
@@ -151,8 +151,8 @@ const TaskActionArea = styled(CardActionArea)<TaskActionAreaProps>(({ theme }) =
 const CtaActionRoot = (props: CtaActionRootProps) => {
   const { taskCta } = props;
   return (
-    <SetupCardTaskCta className={SetupCardTaskCta.displayName}>
-      <CtaAction className={CtaAction.displayName} variant="body2">
+    <SetupCardTaskCta className="WmeTaskCta-root">
+      <CtaAction className="WmeTaskCta-action" variant="body2">
         {taskCta}
       </CtaAction>
       <ChevronRight />
@@ -195,13 +195,13 @@ const SetupCardTask: React.FC<SetupCardProps> = (props) => {
     : button;
 
   return (
-    <Task className={Task.displayName} variant={variantType}>
+    <Task className="WmeTask-root" variant={variantType}>
       <ConditionalWrapper
         condition={variantType === 'task'}
         wrapper={
           (child: React.ReactNode) => (
             <TaskActionArea
-              className={TaskActionArea.displayName}
+              className="WmeTaskActionArea-root"
               onClick={onClick}
               disabled={disabled}
               href={href}

--- a/src/components/setup-card/setup-card.tsx
+++ b/src/components/setup-card/setup-card.tsx
@@ -23,6 +23,5 @@ const StyledSetupCard = styled(Card, {
 }));
 
 export default function SetupCard(props: CardProps) {
-  const { displayName } = StyledSetupCard;
-  return <StyledSetupCard className={displayName} {...props} />;
+  return <StyledSetupCard className="WmeSetupCard-root" {...props} />;
 }

--- a/src/components/split-button/split-button.tsx
+++ b/src/components/split-button/split-button.tsx
@@ -113,7 +113,7 @@ const SplitButton: React.FC<SplitButtonProps> = (props) => {
         variant="contained"
         ref={anchorRef}
         aria-label={ariaLabelGroup}
-        className={StyledButtonGroup.displayName}
+        className="WmeButtonGroup-root"
         {...rest}
       >
         <Button onClick={handleClick}>{options[selectedIndex]}</Button>
@@ -137,14 +137,14 @@ const SplitButton: React.FC<SplitButtonProps> = (props) => {
       >
         {({ TransitionProps }) => (
           <Grow {...TransitionProps}>
-            <StyledPaper className={StyledPaper.displayName}>
+            <StyledPaper className="WmePaper-root">
               <ClickAwayListener onClickAway={handleClose}>
-                <StyledList className={StyledList.displayName} id="split-button-menu" autoFocusItem>
+                <StyledList className="WmeMenuList-root" id="split-button-menu" autoFocusItem>
                   {options.map((option:string, index:number) => (
                     <StyledMenuItem
                       key={option}
                       selected={index === selectedIndex}
-                      className={StyledMenuItem.displayName}
+                      className="WmeMenuItem-root"
                       onClick={(event) => handleMenuItemClick(event, index)}
                     >
                       {option}

--- a/src/components/switch/switch-toggle.tsx
+++ b/src/components/switch/switch-toggle.tsx
@@ -30,7 +30,7 @@ const StyledSwitch = styled(MuiSwitch, {
 }));
 
 const Switch: React.FC<SwitchProps> = (props) => (
-  <StyledSwitch className={StyledSwitch.displayName} {...props} />
+  <StyledSwitch className="WmeSwitch-root" {...props} />
 );
 
 export default Switch;

--- a/src/components/text-input/text-input.tsx
+++ b/src/components/text-input/text-input.tsx
@@ -43,7 +43,7 @@ const TextInput: React.FC<InputBaseProps> = (props) => {
   const formControlContext = useFormControlUnstyledContext();
   return (
     <StyledTextInput
-      className={StyledTextInput.displayName}
+      className="WmeTextInput-root"
       error={formControlContext?.error}
       {...props}
     />

--- a/src/components/toggle-button-group/toggle-button-group.tsx
+++ b/src/components/toggle-button-group/toggle-button-group.tsx
@@ -39,7 +39,7 @@ const ToggleButtonGroup: React.FC<ToggleButtonGroupProps> = (props) => {
     <StyledToggleButtonGroup
       exclusive
       aria-label={ariaLabel}
-      className={StyledToggleButtonGroup.displayName}
+      className="WmeToggleButtonGroup-root"
       {...rest}
     >
       { children }

--- a/src/components/tooltip/tooltip.tsx
+++ b/src/components/tooltip/tooltip.tsx
@@ -17,7 +17,7 @@ const Tooltip: React.FC<TooltipProps> = (props) => {
   const { children, ...rest } = props;
 
   return (
-    <StyledTooltip className={StyledTooltip.displayName} arrow {...rest}>
+    <StyledTooltip className="WmeTooltip-root" arrow {...rest}>
       {children}
     </StyledTooltip>
   );

--- a/src/components/video-embed/video-embed.tsx
+++ b/src/components/video-embed/video-embed.tsx
@@ -41,8 +41,8 @@ const VideoEmbed: React.FC<VideoEmbedProps> = (props) => {
   };
 
   return (
-    <StyledContainer className={StyledContainer.displayName}>
-      <StyledMedia className={StyledMedia.displayName} {...videoProps} />
+    <StyledContainer className="WmeVideoEmbed-root">
+      <StyledMedia className="WmeVideoEmbed-media" {...videoProps} />
     </StyledContainer>
   );
 };

--- a/src/components/wizard-footer/wizard-footer.tsx
+++ b/src/components/wizard-footer/wizard-footer.tsx
@@ -149,8 +149,8 @@ const WizardFooter: React.FC<WizardFooterProps> = (props) => {
 
   if (!hideFooter) {
     return (
-      <WizardFooterContainer className={WizardFooterContainer.displayName} {...rest}>
-        <Prev className={Prev.displayName}>
+      <WizardFooterContainer className="WmeWizardFooter-root" {...rest}>
+        <Prev className="WmeWizardFooter-prev">
           {
             !currStep?.hideBack
             && (
@@ -164,11 +164,11 @@ const WizardFooter: React.FC<WizardFooterProps> = (props) => {
             )
           }
         </Prev>
-        <Nav className={Nav.displayName}>
+        <Nav className="WmeWizardFooter-nav">
           <StyledStepper
             activeStep={maxActiveStep}
             connector={null}
-            className={StyledStepper.displayName}
+            className="WmeStepper-root"
           >
             {
               steps?.map((step) => {
@@ -180,7 +180,7 @@ const WizardFooter: React.FC<WizardFooterProps> = (props) => {
                 return (
                   <Step key={step.id} active={unlocked} completed={unlocked && !isCurrentStep}>
                     <StyledStepButton
-                      className={StyledStepButton.displayName}
+                      className="WmeStepButton-root"
                       disabled={disable || step.disable}
                       onClick={() => onClickStep?.(step)}
                       sx={{ '&:hover': { textDecoration: unlocked ? 'underline' : 'none' } }}
@@ -196,11 +196,11 @@ const WizardFooter: React.FC<WizardFooterProps> = (props) => {
         {
           !currStep?.hideNext
           && (
-            <Next className={Next.displayName}>
+            <Next className="WmeWizardFooter-next">
               {
                 !currStep?.hideSkip
                 && (
-                  <Skip className={Skip.displayName}>
+                  <Skip className="WmeWizardFooter-skip">
                     <Button onClick={onSkip} disabled={disable}>{skipText}</Button>
                   </Skip>
                 )

--- a/src/components/wizard-header/wizard-header.tsx
+++ b/src/components/wizard-header/wizard-header.tsx
@@ -26,7 +26,7 @@ const WizardHeader: React.FC<WizardHeaderProps> = (props) => {
   } = props;
 
   return (
-    <WizardHeaderContainer className={WizardHeaderContainer.displayName}>
+    <WizardHeaderContainer className="WmeWizardHeader-root">
       { children }
     </WizardHeaderContainer>
   );

--- a/src/components/wizard-section-title/wizard-section-title.tsx
+++ b/src/components/wizard-section-title/wizard-section-title.tsx
@@ -73,23 +73,21 @@ const WizardSectionTitle: React.FC<WizardSectionTitleProps> = (props) => {
     ...rest
   } = props;
 
-  const { displayName } = WizardSectionTitleContainer;
-
   return (
     <WizardSectionTitleContainer
-      className={displayName}
+      className="WmeWizardSectionTitle-root"
       width={width}
       bookend={bookend}
       {...rest}
     >
       {iconSrc && (
-        <IconContainer className={IconContainer.displayName}>
+        <IconContainer className="WmeWizardSectionTitle-iconContainer">
           <img src={iconSrc} alt={iconAlt} width={iconWidth} />
         </IconContainer>
       )}
       {heading && (
         <Heading
-          className={Heading.displayName}
+          className="WmeWizardSectionTitle-heading"
           component={headingComponent || 'h2'}
           variant={headingVariant}
         >
@@ -99,7 +97,7 @@ const WizardSectionTitle: React.FC<WizardSectionTitleProps> = (props) => {
       {copy && (
         <Copy
           align={copyAlign && !bookend ? copyAlign : 'inherit'}
-          className={Copy.displayName}
+          className="WmeWizardSectionTitle-copy"
           variant={copyVariant || 'body1'}
         >
           {copy}

--- a/src/components/wizard/wizard.tsx
+++ b/src/components/wizard/wizard.tsx
@@ -46,7 +46,7 @@ const Wizard: React.FC<WmeDialogProps> = (props) => {
       {...rest}
     >
       <Box sx={{ ...bgStyles }}>
-        <StyledDialogContent className={displayName}>
+        <StyledDialogContent className="WmeWizard-dialogContent">
           {children}
         </StyledDialogContent>
       </Box>


### PR DESCRIPTION
### Description
- The classNames being generated from the Styled object were not being output correctly on production builds due to the build process. Talking with Mark, we decided the safest route is to hardcode these values so we have complete control over them. 
- Allows us to keep the MUI format of `className-root` for the class name rather than `classNameRoot` which is what the Styled Ref object created. This aligns better with MUI styleOverride examples.