### PR TITLE
Bump to 0.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@moderntribe/wme",
-  "version": "0.1.21",
+  "version": "0.2.0",
   "private": false,
   "author": "Moderntribe Incubator Team",
   "description": "Components and hooks to build the best UX/UI admin wizards",


### PR DESCRIPTION
### Description
- bump wme framework to v0.2.0 so latest Storebuilder release is unaffected, but we can move forward on dev work within the `project/wme-framework` branch