### PR TITLE
Updates

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@moderntribe/wme",
-  "version": "0.2.1",
+  "version": "1.0.0",
   "private": false,
   "author": "Moderntribe Incubator Team",
   "description": "Components and hooks to build the best UX/UI admin wizards",

--- a/src/components/card-select-item/card-select-item.tsx
+++ b/src/components/card-select-item/card-select-item.tsx
@@ -15,7 +15,7 @@ interface CardSelectItemProps extends ToggleButtonProps {
   secondary?: any;
   footer?: any;
   hasFooter?: boolean;
-  icon?: string;
+  icon?: any;
   cardPadding?: 'sm' | 'md';
   completedIcon?: React.ReactNode;
 }
@@ -108,7 +108,7 @@ const StyleCardSelectIcon = styled('div', {
   alignItems: 'center',
   justifyContent: 'center',
   overflow: 'hidden',
-  '& img': {
+  '& img, & svg': {
     width: theme.spacing(3),
     height: 'auto',
   },
@@ -213,7 +213,8 @@ export default function CardSelectItem(props: CardSelectItemProps) {
       )}
       {icon && (
         <StyleCardSelectIcon className="WmeCardSelectItem-icon">
-          <Box component="img" src={icon} alt="" />
+          { typeof icon === 'object' && icon }
+          { typeof icon === 'string' && <Box component="img" src={icon} alt="" /> }
         </StyleCardSelectIcon>
       )}
       <StyleCardSelectContentOuter className="WmeCardSelectItem-contentOuter">

--- a/src/components/logo/logo.tsx
+++ b/src/components/logo/logo.tsx
@@ -6,7 +6,7 @@ import {
 import { styled } from '@mui/material/styles';
 
 interface LogoContainerProps extends BoxProps {
-  logoSrc?: string;
+  logoSrc?: string | React.ReactNode;
   logoAlt?: string;
   width?: string;
 }
@@ -19,6 +19,10 @@ const LogoContainer = styled(Box, {
   '& img': {
     width: '100%',
   },
+  '& svg': {
+    width: '100%',
+    height: 'auto',
+  }
 }));
 
 const Logo: React.FC<LogoContainerProps> = (props) => {
@@ -26,7 +30,8 @@ const Logo: React.FC<LogoContainerProps> = (props) => {
 
   return (
     <LogoContainer className="WmeLogoContainer-root" width={width}>
-      <img src={logoSrc} alt={logoAlt} />
+      { typeof logoSrc === 'object' && logoSrc }
+      { typeof logoSrc === 'string' && <img src={logoSrc} alt={logoAlt} /> }
     </LogoContainer>
   );
 };

--- a/src/components/wizard-footer/wizard-footer.stories.mdx
+++ b/src/components/wizard-footer/wizard-footer.stories.mdx
@@ -99,6 +99,20 @@ import backArrow from '../../stories/assets/back-arrow.svg';
         }
       }
     },
+    isLastStep: {
+      control: {
+        type: 'boolean',
+      },
+      description: 'Boolean controls function and class name for next button',
+      table: {
+        type: {
+          summary: 'boolean',
+        },
+        defaultValue: {
+          summary: `false`,
+        }
+      }
+    },
     isLoading: {
       control: {
         type: 'boolean',

--- a/src/components/wizard-footer/wizard-footer.tsx
+++ b/src/components/wizard-footer/wizard-footer.tsx
@@ -42,6 +42,7 @@ interface WizardFooterProps extends BoxProps {
   save?: () => void;
   hideFooter: boolean;
   disableAll?: boolean;
+  isLastStep?: boolean;
 }
 
 const WizardFooterContainer = styled(Box, {
@@ -133,11 +134,11 @@ const WizardFooter: React.FC<WizardFooterProps> = (props) => {
     save,
     hideFooter,
     disableAll,
+    isLastStep = false,
     ...rest
   } = props;
 
   const { maxActiveStep } = useMaxActiveStep(activeStep);
-  const isLastStep = activeStep === steps.length - 1;
   const currStep = steps[activeStep];
   const disable = disableAll || currStep?.disableAll;
   let nextButtonClassName = 'WmeWizardFooterNextButton';


### PR DESCRIPTION
Updates based on Framework implementation into GiveWP FTC wizard.
- CardSelect: Adds ability to add component-based images to component
- Wizard Logo: Adds ability to add component-based images to component
- WizardFooter: Adds `isLastStep` prop and removes previous `isLastStep` logic
- Increments package to v1.0.0