### PR TITLE
Chore: Expose Types for use

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@moderntribe/wme",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "private": false,
   "author": "Moderntribe Incubator Team",
   "description": "Components and hooks to build the best UX/UI admin wizards",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   "license": "MIT",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",
+  "types": "dist/esm/types/index.d.ts",
   "files": [
     "dist/**/*.js",
     "dist/**/*.js.map",


### PR DESCRIPTION
## Description
When using the framework in another project, our types were not getting picked up by the IDE. This PR adds the `types` property and path to the framework types to the `package.json` file. The addition allows the IDE to "see" the types we've defined within the framework. 😍 
