### PR TITLE
chore: Copy ListItemCheckout PR into monorepo

### DIFF
--- a/packages/wme-ui/src/components/chip/chip.tsx
+++ b/packages/wme-ui/src/components/chip/chip.tsx
@@ -1,10 +1,20 @@
 import { styled } from '@mui/material/styles';
 import { Chip as MuiChip, ChipProps } from '@mui/material';
 
-const StyledChip = styled(MuiChip)<ChipProps>(({ color, size, theme }) => ({
+export type { ChipProps } from '@mui/material';
+
+const StyledChip = styled(MuiChip)<ChipProps>(({
+  size, theme,
+}) => ({
   flexDirection: 'row-reverse',
   backgroundColor: theme.palette.info.light,
-  color: theme.palette.primary.dark,
+  color: theme.palette.info.dark,
+
+  '&.Mui-disabled': {
+    opacity: 1,
+    backgroundColor: theme.palette.background.grey,
+    color: theme.palette.text.disabled,
+  },
 
   '& .MuiChip-icon': {
     marginRight: theme.spacing(0.5),
@@ -18,13 +28,10 @@ const StyledChip = styled(MuiChip)<ChipProps>(({ color, size, theme }) => ({
       marginLeft: theme.spacing(-0.25),
     },
   }),
-
-  ...(color === 'success'
-  && {
+  '&.MuiChip-colorSuccess': {
     backgroundColor: theme.palette.success.light,
     color: theme.palette.success.dark,
-  }),
-
+  },
 }));
 
 export default function Chip(props: ChipProps) {

--- a/packages/wme-ui/src/components/chip/chip.tsx
+++ b/packages/wme-ui/src/components/chip/chip.tsx
@@ -8,7 +8,7 @@ const StyledChip = styled(MuiChip)<ChipProps>(({
 }) => ({
   flexDirection: 'row-reverse',
   backgroundColor: theme.palette.info.light,
-  color: theme.palette.info.dark,
+  color: theme.palette.primary.dark,
 
   '&.Mui-disabled': {
     opacity: 1,

--- a/packages/wme-ui/src/components/chip/index.ts
+++ b/packages/wme-ui/src/components/chip/index.ts
@@ -1,1 +1,2 @@
+export * from './chip';
 export { default } from './chip';

--- a/packages/wme-ui/src/components/index.ts
+++ b/packages/wme-ui/src/components/index.ts
@@ -147,3 +147,6 @@ export * from './device-selection';
 
 export { default as Switch } from './switch';
 export * from './switch';
+
+export { default as ListItemCheckout } from './list-item-checkout';
+export * from './list-item-checkout';

--- a/packages/wme-ui/src/components/list-item-checkout/index.ts
+++ b/packages/wme-ui/src/components/list-item-checkout/index.ts
@@ -1,0 +1,1 @@
+export { default } from './list-item-checkout';

--- a/packages/wme-ui/src/components/list-item-checkout/list-item-checkout.stories.mdx
+++ b/packages/wme-ui/src/components/list-item-checkout/list-item-checkout.stories.mdx
@@ -1,0 +1,107 @@
+import {
+  ArgsTable,
+  Story,
+  Canvas,
+  Meta
+} from '@storybook/addon-docs';
+import { useState } from 'react';
+import { action } from '@storybook/addon-actions';
+
+import { AddShoppingCartIcon, NotInterestedIcon, CheckCircleIcon } from '@mui/icons-material';
+import { ListItemCheckout } from '..';
+
+<Meta
+  title="Misc/ListItemCheckout"
+  component={ ListItemCheckout }
+  argTypes={{
+    name: {
+      control: "text",
+      description: "Name of the item",
+    },
+    price: {
+      control: "text",
+      description: "Price of the item",
+    },
+    disabled: {
+      control: "boolean",
+      description: "Mark the item as disabled",
+    },
+    selected: {
+      control: "boolean",
+      description: "Mark the item as selected",
+    },
+    chipColor: {
+      control: {
+        defaultValue: "default",
+        type: "select",
+      },
+      description: "Chip color",
+      options: ["default","success"],
+    },
+    chipLabel: {
+      control: "text",
+      description: "Text that displays inside of chip",
+    },
+  }}
+    decorators={[
+    (Story) => (
+      <div style={{  maxWidth: 700, margin: '0 auto' }}>
+        <Story />
+      </div>
+    ),
+  ]}
+/>
+
+export const Template = (args) => {
+  return (
+    <List>
+      <ListItemCheckout onClick={action('ListItemCheckout clicked')} {...args} />
+    </List>
+  );
+};
+
+# ListItemCheckout
+
+An extended version  of <a href="https://mui.com/material-ui/api/list-item/" target="_blank">MUI's ListItem</a>, so you can use any prop provided there. It's prepared to work in checkout pages.
+
+To prevent overcomplicating the component, it doesn't provide any state management, so you need to handle it yourself. Be specially careful with the `selected` and `disabled` props.
+
+
+## Props
+<ArgsTable story="." />
+
+## Canvas
+<Canvas>
+  <Story
+    name="Default"
+    args={{
+      name: 'yourdomain.com',
+      price: "$10.00 / year",
+      chipLabel: 'Available',
+      chipColor: 'success',
+    }}
+  >
+    {Template.bind({})}
+  </Story>
+  <Story
+    name="Disabled"
+    args={{
+      disabled: true,
+      name: 'yourdomain.com',
+      chipLabel: 'Taken',
+    }}
+  >
+    {Template.bind({})}
+  </Story>
+  <Story
+    name="Selected"
+    args={{
+      selected: true,
+      name: 'yourdomain.com',
+      price: "$10.00 / year",
+      chipLabel: 'Selected',
+    }}
+  >
+    {Template.bind({})}
+  </Story>
+</Canvas>

--- a/packages/wme-ui/src/components/list-item-checkout/list-item-checkout.tsx
+++ b/packages/wme-ui/src/components/list-item-checkout/list-item-checkout.tsx
@@ -1,0 +1,118 @@
+import type React from 'react';
+import {
+  Box,
+  ListItem as MuiListItem,
+  ListItemProps,
+  Typography,
+  TypographyProps,
+} from '@mui/material';
+import { styled } from '@mui/material/styles';
+import IconButton from '@mui/material/IconButton';
+import AddShoppingCartIcon from '@mui/icons-material/AddShoppingCart';
+import NotInterestedIcon from '@mui/icons-material/NotInterested';
+import CheckCircleIcon from '@mui/icons-material/CheckCircle';
+
+import { Chip, ChipProps } from '..';
+
+export interface WmeListItemCheckoutProps extends ListItemProps {
+  name?: string;
+  price?: string;
+  disabled?: boolean;
+  selected?: boolean;
+  onClick?: (event: React.MouseEvent<HTMLElement>) => void;
+  icon?: React.ReactElement;
+  iconDisabled?: React.ReactElement;
+  iconSelected?: React.ReactElement;
+  chipColor?: ChipProps['color'];
+  chipLabel?: ChipProps['label'];
+}
+
+const StyledListItemCheckout = styled(MuiListItem, {
+  name: 'WmeListItemCheckout',
+  slot: 'Root',
+})(({ theme }) => ({
+  margin: 0,
+  display: 'flex',
+  gap: theme.spacing(2),
+  '& .MuiButton-text.WmeButton-root': {
+    fontWeight: '600',
+    color: theme.palette.text.disabled,
+  },
+}));
+
+const PrimaryText = styled(Typography, {
+  name: 'WmeListItemCheckout',
+  slot: 'Primary',
+})<TypographyProps & { selected?: boolean }>(({ theme, selected }) => ({
+  display: 'block',
+  fontWeight: 600,
+  color: selected ? theme.palette.primary.dark : theme.palette.text.primary,
+  flexGrow: 1,
+}));
+
+const SecondaryText = styled(Typography, {
+  name: 'WmeListItemCheckout',
+  slot: 'SecondaryText',
+})<TypographyProps>(({ theme }) => ({
+  display: 'block',
+  fontWeight: 600,
+  color: theme.palette.text.primary,
+}));
+
+const StyledListItemCheckoutContentInner = styled(Box, {
+  name: 'WmeListItemCheckout',
+  slot: 'ContentInner',
+})(({ theme }) => ({
+  display: 'flex',
+  alignItems: 'baseline',
+  gap: theme.spacing(2),
+  marginRight: theme.spacing(1),
+}));
+
+const StyledCheckCircleIcon = styled(CheckCircleIcon, {
+  name: 'WmeListItemCheckout',
+  slot: 'CheckCircleIcon',
+})(({ theme }) => ({
+  color: theme.palette.primary.dark,
+}));
+
+const ListItemCheckout: React.FC<WmeListItemCheckoutProps> = (props) => {
+  const {
+    name,
+    price,
+    chipColor,
+    chipLabel,
+    disabled,
+    selected,
+    icon = <AddShoppingCartIcon />,
+    iconDisabled = <NotInterestedIcon />,
+    iconSelected = <StyledCheckCircleIcon />,
+    ...rest
+  } = props;
+
+  function getIconToRender() {
+    if (disabled) return iconDisabled;
+    if (selected) return iconSelected;
+    return icon;
+  }
+  const iconToRender = getIconToRender();
+  return (
+    <StyledListItemCheckout
+      className="WmeListItemCheckout-root"
+      secondaryAction={(
+        <IconButton edge="end" aria-label="add-to-cart" disabled={disabled}>
+          {iconToRender}
+        </IconButton>
+      )}
+      {...rest}
+    >
+      <PrimaryText selected={selected}>{name}</PrimaryText>
+      <StyledListItemCheckoutContentInner className="WmeListItemCheckout-contentInner">
+        <SecondaryText>{price}</SecondaryText>
+        {chipLabel && <Chip color={chipColor} label={chipLabel} disabled={disabled} />}
+      </StyledListItemCheckoutContentInner>
+    </StyledListItemCheckout>
+  );
+};
+
+export default ListItemCheckout;


### PR DESCRIPTION
This PR primarily copies Jorge's `ListItemCheckout` work into the Monorepo. I needed to update one `React` import to `type React` and remove another React import entirely to satisfy the lint.