### PR TITLE
[SITE-26] Store Setup Fix/Improvement

### DIFF
--- a/packages/storebuilder/src/contexts/StoreSetupProvider.tsx
+++ b/packages/storebuilder/src/contexts/StoreSetupProvider.tsx
@@ -125,8 +125,14 @@ const StoreSetupProvider = ({
 
 	const resetFormValue = (prop: keyof StoreSetupFormItemsInterface) => {
 		const formData = storeSetupState.form;
-		formData[ prop ].value = Array.isArray(formData[ prop ].value) ? [] : '';
 		formData[ prop ].touched = false;
+
+		// If reseting Region or State, reset the form values with the storeSetupState values.
+		if (prop === 'region' || prop === 'state') {
+			formData[ prop ].value = storeSetupState[ prop ];
+		} else {
+			formData[ prop ].value = Array.isArray(formData[ prop ].value) ? [] : '';
+		}
 
 		setStoreSetupState({
 			...storeSetupState,

--- a/packages/storebuilder/src/wizards/store-setup/screens/StoreDetails.tsx
+++ b/packages/storebuilder/src/wizards/store-setup/screens/StoreDetails.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { Stack, Typography, MenuItem, SelectChangeEvent } from '@mui/material';
 import {
 	CardSelectGroup,
@@ -40,6 +40,18 @@ const StoreDetails = () => {
 		setProductCount,
 		setProductTypes,
 	} = useStoreSetup();
+
+	const [isProductTypeDisabled, setIsProductTypeDisabled] = useState<boolean>(false);
+	const [isProductCountDisabled, setIsProductCountDisabled] = useState<boolean>(false);
+
+	useEffect(() => {
+		if (completed && productCount.length) {
+			setIsProductCountDisabled(true);
+		}
+		if (completed && productTypes.length) {
+			setIsProductTypeDisabled(true);
+		}
+	}, []);
 
 	const handleCurrencyChange = (event: SelectChangeEvent<unknown>) => {
 		const value = event.target.value as string;
@@ -95,7 +107,7 @@ const StoreDetails = () => {
 						}
 					>
 						<CardSelectGroup
-							disabled={ completed }
+							disabled={ isProductTypeDisabled }
 							exclusive={ false }
 							cardColumns={ 3 }
 							value={ productTypes }
@@ -118,7 +130,7 @@ const StoreDetails = () => {
 						label={ productCountLabelText }
 					>
 						<CardSelectGroup
-							disabled={ completed }
+							disabled={ isProductCountDisabled }
 							exclusive={ true }
 							cardColumns={ 3 }
 							value={ productCount }

--- a/packages/storebuilder/src/wizards/store-setup/screens/StoreDetails.tsx
+++ b/packages/storebuilder/src/wizards/store-setup/screens/StoreDetails.tsx
@@ -30,6 +30,9 @@ const { storeDetails: {
 const cardSelectSx = {
 	'& .WmeCardSelectItem-primary': {
 		fontSize: pxToRem(12),
+	},
+	'&.Mui-disabled .WmeCardSelectItem-icon': {
+		backgroundColor: 'transparent',
 	}
 };
 

--- a/packages/storebuilder/src/wizards/store-setup/screens/StoreDetails.tsx
+++ b/packages/storebuilder/src/wizards/store-setup/screens/StoreDetails.tsx
@@ -35,7 +35,7 @@ const cardSelectSx = {
 
 const StoreDetails = () => {
 	const {
-		storeSetupState: { currency, currencies, productCount, productTypes },
+		storeSetupState: { completed, currency, currencies, productCount, productTypes },
 		setCurrency,
 		setProductCount,
 		setProductTypes,
@@ -95,6 +95,7 @@ const StoreDetails = () => {
 						}
 					>
 						<CardSelectGroup
+							disabled={ completed }
 							exclusive={ false }
 							cardColumns={ 3 }
 							value={ productTypes }
@@ -117,6 +118,7 @@ const StoreDetails = () => {
 						label={ productCountLabelText }
 					>
 						<CardSelectGroup
+							disabled={ completed }
 							exclusive={ true }
 							cardColumns={ 3 }
 							value={ productCount }

--- a/packages/storebuilder/src/wizards/store-setup/screens/StoreDetails.tsx
+++ b/packages/storebuilder/src/wizards/store-setup/screens/StoreDetails.tsx
@@ -41,7 +41,7 @@ const StoreDetails = () => {
 		setProductTypes,
 	} = useStoreSetup();
 
-	const [isProductTypeDisabled, setIsProductTypeDisabled] = useState<boolean>(false);
+	const [isProductTypesDisabled, setIsProductTypesDisabled] = useState<boolean>(false);
 	const [isProductCountDisabled, setIsProductCountDisabled] = useState<boolean>(false);
 
 	useEffect(() => {
@@ -49,7 +49,7 @@ const StoreDetails = () => {
 			setIsProductCountDisabled(true);
 		}
 		if (completed && productTypes.length) {
-			setIsProductTypeDisabled(true);
+			setIsProductTypesDisabled(true);
 		}
 	}, []);
 
@@ -107,7 +107,7 @@ const StoreDetails = () => {
 						}
 					>
 						<CardSelectGroup
-							disabled={ isProductTypeDisabled }
+							disabled={ isProductTypesDisabled }
 							exclusive={ false }
 							cardColumns={ 3 }
 							value={ productTypes }

--- a/packages/wme-ui/src/components/card-select-item/card-select-item.tsx
+++ b/packages/wme-ui/src/components/card-select-item/card-select-item.tsx
@@ -28,7 +28,7 @@ const StyleCardSelectItem = styled(ToggleButton, {
   transition: theme?.transitions?.create(['border-color'], {
     duration: theme.transitions.duration.standard,
   }),
-  '&.MuiButtonBase-root.Mui-selected': {
+  '&.MuiButtonBase-root.MuiToggleButton-root.Mui-selected': {
     backgroundColor: 'transparent',
     borderColor: theme.palette.primary.light,
     borderWidth: 1,


### PR DESCRIPTION
## Fix
### Problem
Skipping the Store Location screen and navigating back was causing the Region and State select inputs to reset, when they should maintain their default (or previously-set) state.

### Solution
Adds logic to the `resetFormValue` function that ensures that the `form` values for Region and State are never empty by returning the value captured in state.

## Improvement
The Product Type and Product Quantity UI is now disabled after the Store Setup wizard is completed **AND** values have been captured for these inputs.
- Makes icon background transparent when CardSelectItem is disabled.
- Fixes border color inconsistency with added specificity in WME-UI component.
