### PR TITLE
[SITE-60] Manage device picker display logic

### DIFF
--- a/packages/sitebuilder/src/contexts/LookAndFeelProvider.tsx
+++ b/packages/sitebuilder/src/contexts/LookAndFeelProvider.tsx
@@ -27,7 +27,7 @@ export interface LookAndFeelProviderContextInterface {
 export const LookAndFeelContext = createContext<LookAndFeelProviderContextInterface | null>(null);
 
 const LookAndFeelProvider = ({ children }: { children: React.ReactNode }) => {
-	const { goToNextStep } = useWizard();
+	const { goToNextStep, setShowDeviceHeader } = useWizard();
 	const [lookAndFeelState, setLookAndFeelState] = useState<LookAndFeelInterface>(LookAndFeelScreenData());
 	const [templates, setTemplates] = useState();
 	const { kadence } = LOOK_AND_FEEL_PROPS;
@@ -75,6 +75,7 @@ const LookAndFeelProvider = ({ children }: { children: React.ReactNode }) => {
 			isImporting: status,
 			showDeleteWarning: lookAndFeelState.showDeleteWarning && false,
 		});
+		setShowDeviceHeader(! status);
 	};
 
 	const setShowDeleteWarning = (status:boolean) => {

--- a/packages/sitebuilder/src/contexts/WizardProvider.tsx
+++ b/packages/sitebuilder/src/contexts/WizardProvider.tsx
@@ -23,6 +23,7 @@ export interface WizardProviderContextInterface {
 	setShowCloseWarning: (showCloseWarning: boolean) => void;
 	setHideExit: (hideExit: boolean) => void;
 	setActiveDevice: (device: string) => void;
+	setShowDeviceHeader: (showDeviceHeader: boolean) => void;
 }
 
 const initialState: WizardProviderStateInterface = {
@@ -58,7 +59,8 @@ const WizardProvider = ({ children }: { children: React.ReactNode }) => {
 		if (currentStep > 1) {
 			setWizardState({
 				...wizardState,
-				hasStepped: true
+				hasStepped: true,
+				showDeviceHeader: true
 			});
 		}
 	}, [currentStep]);
@@ -125,6 +127,13 @@ const WizardProvider = ({ children }: { children: React.ReactNode }) => {
 		});
 	};
 
+	const setShowDeviceHeader = (showDeviceHeader: boolean) => {
+		setWizardState({
+			...wizardState,
+			showDeviceHeader
+		});
+	};
+
 	return (
 		<WizardContext.Provider
 			value={ {
@@ -136,7 +145,8 @@ const WizardProvider = ({ children }: { children: React.ReactNode }) => {
 				closeAll,
 				setShowCloseWarning,
 				setHideExit,
-				setActiveDevice
+				setActiveDevice,
+				setShowDeviceHeader
 			} }
 		>
 			{ children }

--- a/packages/sitebuilder/src/hooks/useWizard.ts
+++ b/packages/sitebuilder/src/hooks/useWizard.ts
@@ -11,7 +11,8 @@ export function useWizard() {
 		closeAll,
 		setShowCloseWarning,
 		setHideExit,
-		setActiveDevice
+		setActiveDevice,
+		setShowDeviceHeader
 	} = useContext(WizardContext) as WizardProviderContextInterface;
 	return {
 		wizardState,
@@ -22,6 +23,7 @@ export function useWizard() {
 		closeAll,
 		setShowCloseWarning,
 		setHideExit,
-		setActiveDevice
+		setActiveDevice,
+		setShowDeviceHeader
 	};
 }

--- a/packages/sitebuilder/src/wizards/WizardHeader.tsx
+++ b/packages/sitebuilder/src/wizards/WizardHeader.tsx
@@ -12,7 +12,7 @@ export interface WizardHeaderInterface {
 }
 
 const WizardHeader: React.FC<WizardHeaderInterface> = () => {
-	const { wizardState: { showCloseWarning, hideExit }, setShowCloseWarning, closeAll, currentStep } = useWizard();
+	const { wizardState: { showCloseWarning, hideExit, showDeviceHeader }, setShowCloseWarning, closeAll } = useWizard();
 	const location = useLocation();
 
 	const handleExitClick = () => {
@@ -31,7 +31,7 @@ const WizardHeader: React.FC<WizardHeaderInterface> = () => {
 					width="100"
 					logoSrc={ <StoreBuilderLogo /> }
 				/>
-				{ location.pathname === '/wizard/look-and-feel' && currentStep > 1 ? <ModalDeviceSelection /> : null }
+				{ location.pathname === '/wizard/look-and-feel' && showDeviceHeader ? <ModalDeviceSelection /> : null }
 				{
 					! hideExit &&
 					<ExitButton onClick={ handleExitClick }>


### PR DESCRIPTION
## Problem
The device picker was appearing on the importing screen where it shouldn't bee seen.

## Solution
I returned the `setShowDeviceHeader` function back to the `LookAndFeelProvider`, but changed how the function is called. Rather than trying to set `showDeviceHeader` at the screen level, the logic is now all within `LookAndFeelProvider`.