### PR TITLE
fix: Adds support for non 12 month terms

### DIFF
--- a/packages/sitebuilder/src/utils/parseDomainListItem.ts
+++ b/packages/sitebuilder/src/utils/parseDomainListItem.ts
@@ -1,4 +1,4 @@
-import { sprintf } from '@wordpress/i18n';
+import { sprintf, _n } from '@wordpress/i18n';
 import { GoLiveStringData } from '@sb/wizards/go-live/data/constants';
 
 type DomainListItem = {
@@ -10,13 +10,24 @@ type DomainListItem = {
 	selected: boolean,
 }
 
-function getPrice(price: string, isAvailable: boolean) {
+function getPrice(termFees: DomainTermFees, isAvailable: boolean) {
 	if (! isAvailable) {
 		return undefined;
 	}
-	return sprintf('%1$s %2$s',
+
+	// Get the terms available for this domain.
+	const terms = Object.keys(termFees);
+	const shortestTerm = Math.min(...terms.map((term) => Number(term)));
+	const termToYear = shortestTerm / 12;
+	const price = termFees[ shortestTerm ];
+
+	// eslint-disable-next-line @wordpress/i18n-translator-comments
+	const perYear = _n('year', 'years', termToYear, 'nexcess-mapps');
+
+	return sprintf('%1$s / %2$s %3$s',
 		price,
-		GoLiveStringData.domainItems.perYear
+		termToYear,
+		perYear
 	);
 }
 
@@ -41,7 +52,7 @@ export function parseDomainListItem(domain: Domain, selected: boolean): DomainLi
 	return ({
 		name: domain.domain,
 		disabled: ! domain.is_available,
-		price: getPrice(domain.package.term_fees[ '12' ], domain.is_available),
+		price: getPrice(domain.package.term_fees, domain.is_available),
 		chipLabel: getChipLabel(domain.is_available, selected),
 		chipColor: getChipColor(domain.is_available, selected),
 		selected,

--- a/packages/sitebuilder/src/wizards/go-live/data/constants.ts
+++ b/packages/sitebuilder/src/wizards/go-live/data/constants.ts
@@ -87,7 +87,6 @@ export const GoLiveStringData = {
 		nevermind: __('Do not skip verification', 'nexcess-mapps')
 	},
 	domainItems: {
-		perYear: __('/ year', 'nexcess-mapps'),
 		taken: __('Taken', 'nexcess-mapps'),
 		selected: __('Selected', 'nexcess-mapps'),
 		available: __('Available', 'nexcess-mapps'),

--- a/packages/sitebuilder/src/wizards/go-live/data/constants.ts
+++ b/packages/sitebuilder/src/wizards/go-live/data/constants.ts
@@ -10,7 +10,7 @@ export const GoLiveStringData = {
 		errorMessageVerification: __('There was an error while verifying your site\'s domain.', 'nexcess-mapps'),
 		errorNotPointed: __('This domain is not pointing to your website.', 'nexcess-mapps'), // TODO: change wording to use product name
 		errorNotRegistered: __('This domain is not registered.', 'nexcess-mapps'),
-		errorGeneral: __('We\'re unable to connect your domain.', 'nexcess-mapps'),
+		errorGeneral: __('We\'re unable to connect your domain.', 'nexcess-mapps')
 	},
 	start: {
 		screenTitle1: __('Set your site domain', 'nexcess-mapps'),
@@ -30,7 +30,7 @@ export const GoLiveStringData = {
 		screenNotice: __('If you\'re using a subdomain (ex: store.example.com), please stop here and reach out to support at', 'nexcess-mapps'),
 		goLiveLabelText: __('Enter the domain you want to connect', 'nexcess-mapps'),
 		goLivePlaceholderText: __('yourdomain.com', 'nexcess-mapps'),
-		errorDomainFormat: __('The domain entered does not appear to be a valid format.', 'nexcess-mapps'),
+		errorDomainFormat: __('The domain entered does not appear to be a valid format.', 'nexcess-mapps')
 	},
 	updateSiteUrl: {
 		screenTitle: __('You\'re ready to go live with', 'nexcess-mapps'),
@@ -46,7 +46,7 @@ export const GoLiveStringData = {
 	},
 	claimYourDomain: {
 		screenTitle: __('is all yours!', 'nexcess-mapps'),
-		screenDescription: __('While a new domain is often ready for use within an hour, it can take up to 8 hours to completely process.', 'nexcess-mapps'),
+		screenDescription: __('While a new domain is often ready for use within an hour, it can take up to 8 hours to completely process.', 'nexcess-mapps')
 	},
 	errorDomainGeneral: {
 		accountContent: __('It looks like we\'re having trouble connecting your domain.', 'nexcess-mapps'),
@@ -72,7 +72,7 @@ export const GoLiveStringData = {
 		advancedLabelPart2: __('Skip verification', 'nexcess-mapps'),
 		advancedContentPart1: __('By default, we check that the appropriate DNS records are set before changing your domain. If you\'re behind a proxy or are using another more advanced DNS technique, you may wish to skip this validation.', 'nexcess-mapps'),
 		advancedContentPart2: __('Your site may become inaccessible if its DNS records are invalid, so please double-check your DNS configuration before continuing.', 'nexcess-mapps'),
-		advancedContentPart3: __('If anything does go wrong, please reach out to support and we\'ll get you up and running!', 'nexcess-mapps'),
+		advancedContentPart3: __('If anything does go wrong, please reach out to support and we\'ll get you up and running!', 'nexcess-mapps')
 	},
 	successDomainConnected: {
 		statusSuccessPart1: __('Your domain is ready to connect!', 'nexcess-mapps'),
@@ -89,6 +89,6 @@ export const GoLiveStringData = {
 	domainItems: {
 		taken: __('Taken', 'nexcess-mapps'),
 		selected: __('Selected', 'nexcess-mapps'),
-		available: __('Available', 'nexcess-mapps'),
+		available: __('Available', 'nexcess-mapps')
 	}
 };

--- a/packages/sitebuilder/src/wizards/go-live/screens/ConnectWithNexcess.tsx
+++ b/packages/sitebuilder/src/wizards/go-live/screens/ConnectWithNexcess.tsx
@@ -58,7 +58,7 @@ const ConnectWithNexcess = () => {
 										},
 										'& .MuiTouchRipple-root': {
 											display: 'none',
-									},
+										},
 									}
 								} } />
 								{ index < selectedDomains.length - 1 && (

--- a/packages/sitebuilder/src/wizards/go-live/screens/FindDomain.tsx
+++ b/packages/sitebuilder/src/wizards/go-live/screens/FindDomain.tsx
@@ -74,12 +74,12 @@ const FindDomain = () => {
 					endAdornment={
 						<InputAdornment position="end">
 							{ isFetching ? (
-                <Box component="img" src={ `${ IMAGE_DIR }loading-icon.svg` } sx={ loadingSx } /> 
-              ) : (
-                <IconButton type="submit" sx={{ position: 'absolute', right: '-12px', padding: '6px' } }>
-                  <Search /> 
-                </IconButton>
-              ) }
+								<Box component="img" src={ `${ IMAGE_DIR }loading-icon.svg` } sx={ loadingSx } />
+							) : (
+								<IconButton type="submit" sx={ { position: 'absolute', right: '-12px', padding: '6px' } }>
+									<Search />
+								</IconButton>
+							) }
 						</InputAdornment>
 					}
 					value={ internalSearch }

--- a/packages/storebuilder/CHANGELOG.md
+++ b/packages/storebuilder/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @moderntribe/storebuilder
 
+## 1.4.2
+
+### Patch Changes
+
+- 514f996: Linting fixes
+
+## 1.4.1
+
+### Patch Changes
+
+- 996d0f7: Content replacement on Store Setup screen
+
 ## 1.4.0
 
 ### Minor Changes

--- a/packages/storebuilder/package.json
+++ b/packages/storebuilder/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@moderntribe/storebuilder",
-	"version": "1.4.0",
+	"version": "1.4.2",
 	"description": "StoreBuilder foundation",
 	"main": "dist/index.js",
 	"files": [

--- a/packages/storebuilder/src/wizards/store-setup/data/constants.ts
+++ b/packages/storebuilder/src/wizards/store-setup/data/constants.ts
@@ -23,17 +23,13 @@ export const StoreSetupStringData = {
 		productTypesLabelText: __('What types of products are you selling?', 'nexcess-mapps'),
 		productTypesHelperText: __('Select all that apply.', 'nexcess-mapps'),
 		productCountLabelText: __('How many products do you have?', 'nexcess-mapps')
-
 	},
 	complete: {
 		title: __('Nice work! Let\'s keep going.', 'nexcess-mapps'),
-		copy: __(
-      'Next up: Add products and set up your payment method.'
-			'nexcess-mapps'
-		),
+		copy: __('Next up: Add products and set up your payment method.', 'nexcess-mapps')
 	},
 	submitForm: {
-		errorMessage: __('There was an error saving the data.', 'nexcess-mapps'),
+		errorMessage: __('There was an error saving the data.', 'nexcess-mapps')
 	}
 };
 
@@ -42,20 +38,20 @@ export const productTypeOptions = [
 		value: 'physical-goods',
 		label: __('Physical Goods', 'nexcess-mapps'),
 		icon: `${ IMAGE_DIR }product-type-physical.png`,
-		name: 'product_type',
+		name: 'product_type'
 	},
 	{
 		value: 'digital-goods',
 		label: __('Digital Goods', 'nexcess-mapps'),
 		icon: `${ IMAGE_DIR }product-type-digital.png`,
-		name: 'product_type',
+		name: 'product_type'
 	},
 	{
 		value: 'services',
 		label: __('Services', 'nexcess-mapps'),
 		icon: `${ IMAGE_DIR }product-type-services.png`,
-		name: 'product_type',
-	},
+		name: 'product_type'
+	}
 ];
 
 export const productCountOptions = [
@@ -63,18 +59,18 @@ export const productCountOptions = [
 		value: '1-10',
 		label: '1-10',
 		icon: `${ IMAGE_DIR }ftc-product-count-1-10.svg`,
-		name: 'product_count',
+		name: 'product_count'
 	},
 	{
 		value: '10-30',
 		label: '10-30',
 		icon: `${ IMAGE_DIR }ftc-product-count-10-30.svg`,
-		name: 'product_count',
+		name: 'product_count'
 	},
 	{
 		value: '30-99',
 		label: '30-99+',
 		icon: `${ IMAGE_DIR }ftc-product-count-30-99.svg`,
-		name: 'product_count',
-	},
+		name: 'product_count'
+	}
 ];


### PR DESCRIPTION
## Problem
Domains may be sold with terms ranging from 12 - 120 months. Domains returning with a non-12 key were displaying "undefined". Some domains are sold with terms starting at 24 months.

## Solution
Update the `getPrice` function to accept all terms and find the shortest term. Use the shortest term duration to display the "per year" price and message.

http://p.tri.be/i/cdRa1E