### PR TITLE
Multiline input field

### DIFF
--- a/packages/wme-ui/src/components/text-input/text-input.stories.mdx
+++ b/packages/wme-ui/src/components/text-input/text-input.stories.mdx
@@ -42,6 +42,18 @@ import { TextInput } from "..";
       defaultValue: "field-id",
       description: "The id of the input element.",
     },
+    minRows: {
+      control: "number",
+      description:
+        "Minimum number of rows to display when multiline option is set to true.",
+      defaultValue: 1,
+    },
+    multiline: {
+      control: "boolean",
+      description:
+        "If true, the input will have auto-sizing according to the line count",
+      defaultValue: false,
+    },
     name: {
       control: "string",
       defaultValue: "field-name",
@@ -133,4 +145,14 @@ export default TextInput;
   >
     {Template.bind({})}
   </Story>
+  <Story
+      name="TextInputMultiline"
+      args={{
+        defaultValue: "Weep; for not all tears are an evil.",
+        multiline: true,
+        minRows: 4,
+      }}
+    >
+      {Template.bind({})}
+    </Story>
 </Canvas>


### PR DESCRIPTION
This PR adds `minRows` and `multiline` props into the TextInput component and creates the corresponding story for those.

## Screenshot
![Screen Shot 2022-11-18 at 21 13 18](https://user-images.githubusercontent.com/4440378/202774392-acf7d4dd-1f53-48cb-80ff-c679aed5baf2.png)
