### PR TITLE
Cleanup types and outdated local dev configurations

### DIFF
--- a/packages/sitebuilder/package.json
+++ b/packages/sitebuilder/package.json
@@ -11,7 +11,7 @@
 	],
 	"scripts": {
 		"build": "rollup --config node:@moderntribe/rollup-config --environment NODE_ENV:production",
-		"dev": "yalc=true rollup --config node:@moderntribe/rollup-config --watch",
+		"dev": "rollup --config node:@moderntribe/rollup-config --watch",
 		"lint": "eslint . --ext ts,tsx",
 		"lint:fix": "eslint . --fix --ext ts,tsx",
 		"test": "echo \"Error: no test specified\" && exit 1"
@@ -54,7 +54,6 @@
 		"prettier": "^2.7.1",
 		"rollup": "^2.79.0",
 		"rollup-plugin-copy": "^3.4.0",
-		"rollup-plugin-shell": "^1.0.8",
 		"ts-loader": "^9.3.1",
 		"typescript": "^4.7.4",
 		"wp-types": "^3.60.0"

--- a/packages/sitebuilder/src/components/Loadable.tsx
+++ b/packages/sitebuilder/src/components/Loadable.tsx
@@ -1,7 +1,7 @@
 import { Suspense } from 'react';
 import { Loading } from './Loading';
 
-const Loadable = <T extends { fullscreen?: boolean }>(Component: React.ComponentType<T>) => (props: T) => {
+const Loadable = <T extends { fullscreen?: boolean }>(Component: React.FunctionComponent<T>) => (props: T) => {
 	const {
 		fullscreen,
 	} = props;

--- a/packages/storebuilder/package.json
+++ b/packages/storebuilder/package.json
@@ -11,7 +11,7 @@
 	],
 	"scripts": {
 		"build": "rollup --config node:@moderntribe/rollup-config --environment NODE_ENV:production",
-		"dev": "yalc=true rollup --config node:@moderntribe/rollup-config --watch",
+		"dev": "rollup --config node:@moderntribe/rollup-config --watch",
 		"lint": "eslint . --ext ts,tsx",
 		"lint:fix": "eslint . --fix --ext ts,tsx",
 		"test": "echo \"Error: no test specified\" && exit 1"
@@ -54,7 +54,6 @@
 		"prettier": "^2.7.1",
 		"rollup": "^2.79.0",
 		"rollup-plugin-copy": "^3.4.0",
-		"rollup-plugin-shell": "^1.0.8",
 		"ts-loader": "^9.3.1",
 		"typescript": "^4.7.4",
 		"wp-types": "^3.60.0"

--- a/packages/storebuilder/src/components/Loadable.tsx
+++ b/packages/storebuilder/src/components/Loadable.tsx
@@ -1,7 +1,7 @@
 import { Suspense } from 'react';
 import { Loading } from './Loading';
 
-const Loadable = <T extends { fullscreen?: boolean }>(Component: React.ComponentType<T>) => (props: T) => {
+const Loadable = <T extends { fullscreen?: boolean }>(Component: React.FunctionComponent<T>) => (props: T) => {
 	const {
 		fullscreen,
 	} = props;

--- a/plugins/wme-sitebuilder/webpack.mix.js
+++ b/plugins/wme-sitebuilder/webpack.mix.js
@@ -46,9 +46,6 @@ mix.webpackConfig({
 			'@sb': __dirname + '/assets/js/store-details',
 		}
 	},
-	watchOptions: {
-		ignored: ['node_modules/*/!(@moderntribe/*)/**/'],
-	},
 });
 
 // Enable BrowserSync.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -92,7 +92,6 @@ importers:
       react-router-dom: ^6.4.2
       rollup: ^2.79.0
       rollup-plugin-copy: ^3.4.0
-      rollup-plugin-shell: ^1.0.8
       ts-loader: ^9.3.1
       typescript: ^4.7.4
       wp-types: ^3.60.0
@@ -130,7 +129,6 @@ importers:
       prettier: 2.8.1
       rollup: 2.79.1
       rollup-plugin-copy: 3.4.0
-      rollup-plugin-shell: 1.0.9
       ts-loader: 9.4.2_3fkjkrd3audxnith3e7fo4fnxi
       typescript: 4.9.4
       wp-types: 3.61.0
@@ -169,7 +167,6 @@ importers:
       react-router-dom: ^6.4.2
       rollup: ^2.79.0
       rollup-plugin-copy: ^3.4.0
-      rollup-plugin-shell: ^1.0.8
       ts-loader: ^9.3.1
       typescript: ^4.7.4
       wp-types: ^3.60.0
@@ -207,7 +204,6 @@ importers:
       prettier: 2.8.1
       rollup: 2.79.1
       rollup-plugin-copy: 3.4.0
-      rollup-plugin-shell: 1.0.9
       ts-loader: 9.4.2_3fkjkrd3audxnith3e7fo4fnxi
       typescript: 4.9.4
       wp-types: 3.61.0
@@ -786,6 +782,20 @@ packages:
       lru-cache: 5.1.1
       semver: 6.3.0
 
+  /@babel/helper-compilation-targets/7.20.7_@babel+core@7.20.5:
+    resolution: {integrity: sha512-4tGORmfQcrc+bvrjb5y3dG9Mx1IOZjsHqQVUz7XCNHO+iTmqxWnVg3KRygjGmpRLJGdQSKuvFinbIb0CnZwHAQ==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0
+    dependencies:
+      '@babel/compat-data': 7.20.10
+      '@babel/core': 7.20.5
+      '@babel/helper-validator-option': 7.18.6
+      browserslist: 4.21.4
+      lru-cache: 5.1.1
+      semver: 6.3.0
+    dev: true
+
   /@babel/helper-compilation-targets/7.20.7_@babel+core@7.20.7:
     resolution: {integrity: sha512-4tGORmfQcrc+bvrjb5y3dG9Mx1IOZjsHqQVUz7XCNHO+iTmqxWnVg3KRygjGmpRLJGdQSKuvFinbIb0CnZwHAQ==}
     engines: {node: '>=6.9.0'}
@@ -1013,10 +1023,10 @@ packages:
       '@babel/core': ^7.4.0-0
     dependencies:
       '@babel/core': 7.20.7
-      '@babel/helper-compilation-targets': 7.20.7_@babel+core@7.20.7
+      '@babel/helper-compilation-targets': 7.20.0_@babel+core@7.20.7
       '@babel/helper-module-imports': 7.18.6
       '@babel/helper-plugin-utils': 7.20.2
-      '@babel/traverse': 7.20.10
+      '@babel/traverse': 7.20.5
       debug: 4.3.4
       lodash.debounce: 4.0.8
       resolve: 1.22.1
@@ -1046,7 +1056,7 @@ packages:
       '@babel/core': ^7.4.0-0
     dependencies:
       '@babel/core': 7.20.5
-      '@babel/helper-compilation-targets': 7.20.0_@babel+core@7.20.5
+      '@babel/helper-compilation-targets': 7.20.7_@babel+core@7.20.5
       '@babel/helper-plugin-utils': 7.20.2
       debug: 4.3.4
       lodash.debounce: 4.0.8
@@ -1062,7 +1072,7 @@ packages:
       '@babel/core': ^7.4.0-0
     dependencies:
       '@babel/core': 7.20.7
-      '@babel/helper-compilation-targets': 7.20.0_@babel+core@7.20.7
+      '@babel/helper-compilation-targets': 7.20.7_@babel+core@7.20.7
       '@babel/helper-plugin-utils': 7.20.2
       debug: 4.3.4
       lodash.debounce: 4.0.8
@@ -1179,7 +1189,7 @@ packages:
       '@babel/helper-annotate-as-pure': 7.18.6
       '@babel/helper-environment-visitor': 7.18.9
       '@babel/helper-wrap-function': 7.20.5
-      '@babel/types': 7.20.5
+      '@babel/types': 7.20.7
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -1194,7 +1204,7 @@ packages:
       '@babel/helper-annotate-as-pure': 7.18.6
       '@babel/helper-environment-visitor': 7.18.9
       '@babel/helper-wrap-function': 7.20.5
-      '@babel/types': 7.20.5
+      '@babel/types': 7.20.7
     transitivePeerDependencies:
       - supports-color
 
@@ -1900,7 +1910,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.20.5
-      '@babel/helper-create-class-features-plugin': 7.20.12_@babel+core@7.20.5
+      '@babel/helper-create-class-features-plugin': 7.20.7_@babel+core@7.20.5
       '@babel/helper-plugin-utils': 7.20.2
     transitivePeerDependencies:
       - supports-color
@@ -1913,7 +1923,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.20.7
-      '@babel/helper-create-class-features-plugin': 7.20.12_@babel+core@7.20.7
+      '@babel/helper-create-class-features-plugin': 7.20.7_@babel+core@7.20.7
       '@babel/helper-plugin-utils': 7.20.2
     transitivePeerDependencies:
       - supports-color
@@ -2318,7 +2328,6 @@ packages:
     dependencies:
       '@babel/core': 7.20.5
       '@babel/helper-plugin-utils': 7.20.2
-    dev: true
 
   /@babel/plugin-syntax-jsx/7.18.6_@babel+core@7.20.7:
     resolution: {integrity: sha512-6mmljtAedFGTWu2p/8WIORGwy+61PLgOMPOdazc7YoJ9ZCWUyFy3A6CpPkRKLKD1ToAesxX8KGEViAiLo9N+7Q==}
@@ -3027,7 +3036,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.20.5
-      '@babel/helper-compilation-targets': 7.20.0_@babel+core@7.20.5
+      '@babel/helper-compilation-targets': 7.20.7_@babel+core@7.20.5
       '@babel/helper-function-name': 7.19.0
       '@babel/helper-plugin-utils': 7.20.2
     dev: true
@@ -3039,7 +3048,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.20.7
-      '@babel/helper-compilation-targets': 7.20.0_@babel+core@7.20.7
+      '@babel/helper-compilation-targets': 7.20.7_@babel+core@7.20.7
       '@babel/helper-function-name': 7.19.0
       '@babel/helper-plugin-utils': 7.20.2
 
@@ -3238,7 +3247,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.20.5
-      '@babel/helper-module-transforms': 7.20.2
+      '@babel/helper-module-transforms': 7.20.11
       '@babel/helper-plugin-utils': 7.20.2
     transitivePeerDependencies:
       - supports-color
@@ -3251,7 +3260,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.20.7
-      '@babel/helper-module-transforms': 7.20.2
+      '@babel/helper-module-transforms': 7.20.11
       '@babel/helper-plugin-utils': 7.20.2
     transitivePeerDependencies:
       - supports-color
@@ -3335,7 +3344,7 @@ packages:
     dependencies:
       '@babel/core': 7.20.5
       '@babel/helper-plugin-utils': 7.20.2
-      '@babel/helper-replace-supers': 7.19.1
+      '@babel/helper-replace-supers': 7.20.7
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -3348,7 +3357,7 @@ packages:
     dependencies:
       '@babel/core': 7.20.7
       '@babel/helper-plugin-utils': 7.20.2
-      '@babel/helper-replace-supers': 7.19.1
+      '@babel/helper-replace-supers': 7.20.7
     transitivePeerDependencies:
       - supports-color
 
@@ -3490,7 +3499,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.20.5
-      '@babel/plugin-transform-react-jsx': 7.20.7_@babel+core@7.20.5
+      '@babel/plugin-transform-react-jsx': 7.19.0_@babel+core@7.20.5
     dev: true
 
   /@babel/plugin-transform-react-jsx-development/7.18.6_@babel+core@7.20.7:
@@ -3500,7 +3509,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.20.7
-      '@babel/plugin-transform-react-jsx': 7.20.7_@babel+core@7.20.7
+      '@babel/plugin-transform-react-jsx': 7.19.0_@babel+core@7.20.7
 
   /@babel/plugin-transform-react-jsx/7.19.0_@babel+core@7.20.12:
     resolution: {integrity: sha512-UVEvX3tXie3Szm3emi1+G63jyw1w5IcMY0FSKM+CRnKRI5Mr1YbCNgsSTwoTwKphQEG9P+QqmuRFneJPZuHNhg==}
@@ -3581,6 +3590,7 @@ packages:
       '@babel/helper-plugin-utils': 7.20.2
       '@babel/plugin-syntax-jsx': 7.18.6_@babel+core@7.20.7
       '@babel/types': 7.20.7
+    dev: false
 
   /@babel/plugin-transform-react-pure-annotations/7.18.6_@babel+core@7.20.12:
     resolution: {integrity: sha512-I8VfEPg9r2TRDdvnHgPepTKvuRomzA8+u+nhY7qSI1fR2hRNebasZEETLyM5mAUr0Ku56OkXJ0I7NHJnO6cJiQ==}
@@ -4258,7 +4268,7 @@ packages:
       '@babel/helper-plugin-utils': 7.20.2
       '@babel/plugin-proposal-unicode-property-regex': 7.18.6_@babel+core@7.20.5
       '@babel/plugin-transform-dotall-regex': 7.18.6_@babel+core@7.20.5
-      '@babel/types': 7.20.5
+      '@babel/types': 7.20.7
       esutils: 2.0.3
     dev: true
 
@@ -4271,7 +4281,7 @@ packages:
       '@babel/helper-plugin-utils': 7.20.2
       '@babel/plugin-proposal-unicode-property-regex': 7.18.6_@babel+core@7.20.7
       '@babel/plugin-transform-dotall-regex': 7.18.6_@babel+core@7.20.7
-      '@babel/types': 7.20.5
+      '@babel/types': 7.20.7
       esutils: 2.0.3
 
   /@babel/preset-react/7.18.6_@babel+core@7.20.12:
@@ -4981,6 +4991,7 @@ packages:
       find-root: 1.1.0
       source-map: 0.5.7
       stylis: 4.1.3
+    dev: false
 
   /@emotion/babel-plugin/11.10.5_@babel+core@7.20.5:
     resolution: {integrity: sha512-xE7/hyLHJac7D2Ve9dKroBBZqBT7WuPQmWcq7HSGb84sUuP4mlOWoB8dvVfD9yk5DHkU1m6RW7xSoDtnQHNQeA==}
@@ -5000,7 +5011,6 @@ packages:
       find-root: 1.1.0
       source-map: 0.5.7
       stylis: 4.1.3
-    dev: true
 
   /@emotion/cache/11.10.5:
     resolution: {integrity: sha512-dGYHWyzTdmK+f2+EnIGBpkz1lKc4Zbj2KHd4cX3Wi8/OWr5pKslNjc3yABKH4adRGCvSX4VDC0i04mrrq0aiRA==}
@@ -5069,7 +5079,6 @@ packages:
       '@types/react': 17.0.52
       hoist-non-react-statics: 3.3.2
       react: 17.0.2
-    dev: true
 
   /@emotion/react/11.10.5_nehdyrcubdy45i2h35h56gfg7i:
     resolution: {integrity: sha512-TZs6235tCJ/7iF6/rvTaOH4oxQg2gMAcdHemjwLKIjKz4rRuYe1HJ2TQJKnAcRAfOUDdU8XoDadCe1rl72iv8A==}
@@ -5094,6 +5103,7 @@ packages:
       '@types/react': 17.0.52
       hoist-non-react-statics: 3.3.2
       react: 17.0.2
+    dev: false
 
   /@emotion/serialize/1.1.1:
     resolution: {integrity: sha512-Zl/0LFggN7+L1liljxXdsVSVlg6E/Z/olVWpfxUTxOAmi8NU7YoeWeLfi1RmnB2TATHoaWwIBRoL+FvAJiTUQA==}
@@ -5154,7 +5164,6 @@ packages:
       '@emotion/utils': 1.2.0
       '@types/react': 17.0.52
       react: 17.0.2
-    dev: true
 
   /@emotion/styled/11.10.5_wnlametqvv4n76fxzegmuwubuy:
     resolution: {integrity: sha512-8EP6dD7dMkdku2foLoruPCNkRevzdcBaY6q0l0OsbyJK+x8D9HWjX27ARiSIKNF634hY9Zdoedh8bJCiva8yZw==}
@@ -5179,6 +5188,7 @@ packages:
       '@emotion/utils': 1.2.0
       '@types/react': 17.0.52
       react: 17.0.2
+    dev: false
 
   /@emotion/unitless/0.8.0:
     resolution: {integrity: sha512-VINS5vEYAscRl2ZUDiT3uMPlrFQupiKgHz5AA4bCH1miKBg4qtwkim1qPmJj/4WG6TreYMY111rEFsjupcOKHw==}
@@ -6017,14 +6027,14 @@ packages:
       '@types/react':
         optional: true
     dependencies:
-      '@babel/runtime': 7.20.7
+      '@babel/runtime': 7.20.6
       '@emotion/react': 11.10.5_64k6h7xsf5jw26ymy7ush5uuyi
       '@emotion/styled': 11.10.5_ix4t66qa52ydagavywmj5pxy2q
       '@mui/base': 5.0.0-alpha.110_sfoxds7t5ydpegc3knd667wn6m
       '@mui/material': 5.11.3_mpum5pu5vxdmtbvcevx44455ti
-      '@mui/system': 5.11.2_3lsrph6se4xquylogkb5yq6ogu
+      '@mui/system': 5.11.0_3lsrph6se4xquylogkb5yq6ogu
       '@mui/types': 7.2.3
-      '@mui/utils': 5.11.2_react@17.0.2
+      '@mui/utils': 5.11.0_react@17.0.2
       clsx: 1.2.1
       prop-types: 15.8.1
       react: 17.0.2
@@ -6050,8 +6060,8 @@ packages:
         optional: true
     dependencies:
       '@babel/runtime': 7.20.6
-      '@emotion/react': 11.10.5_nehdyrcubdy45i2h35h56gfg7i
-      '@emotion/styled': 11.10.5_wnlametqvv4n76fxzegmuwubuy
+      '@emotion/react': 11.10.5_czskpwcgwtkufrblwuek25f2b4
+      '@emotion/styled': 11.10.5_sebsp7644knzvh4a72jultvi6e
       '@mui/base': 5.0.0-alpha.110_gzv7pa6nrbev3fs6gyzn7sadkq
       '@mui/core-downloads-tracker': 5.11.0
       '@mui/system': 5.11.0_nj4y2rcimqny27utrl764tjxdm
@@ -6118,6 +6128,22 @@ packages:
       prop-types: 15.8.1
       react: 17.0.2
 
+  /@mui/private-theming/5.11.0_react@17.0.2:
+    resolution: {integrity: sha512-UFQLb9x5Sj4pg2GhhCGw3Ls/y1Hw/tz9RsBrULvUF0Vgps1z19o7XTq2xqUvp7pN7fJTW7eVIT2gwVg2xlk8PQ==}
+    engines: {node: '>=12.0.0'}
+    peerDependencies:
+      '@types/react': ^17.0.0 || ^18.0.0
+      react: ^17.0.0 || ^18.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+    dependencies:
+      '@babel/runtime': 7.20.6
+      '@mui/utils': 5.11.0_react@17.0.2
+      prop-types: 15.8.1
+      react: 17.0.2
+    dev: false
+
   /@mui/private-theming/5.11.2_react@17.0.2:
     resolution: {integrity: sha512-qZwMaqRFPwlYmqwVKblKBGKtIjJRAj3nsvX93pOmatsXyorW7N/0IPE/swPgz1VwChXhHO75DwBEx8tB+aRMNg==}
     engines: {node: '>=12.0.0'}
@@ -6149,11 +6175,40 @@ packages:
     dependencies:
       '@babel/runtime': 7.20.7
       '@emotion/cache': 11.10.5
-      '@emotion/react': 11.10.5_nehdyrcubdy45i2h35h56gfg7i
-      '@emotion/styled': 11.10.5_wnlametqvv4n76fxzegmuwubuy
+      '@emotion/react': 11.10.5_czskpwcgwtkufrblwuek25f2b4
+      '@emotion/styled': 11.10.5_sebsp7644knzvh4a72jultvi6e
       csstype: 3.1.1
       prop-types: 15.8.1
       react: 17.0.2
+
+  /@mui/system/5.11.0_3lsrph6se4xquylogkb5yq6ogu:
+    resolution: {integrity: sha512-HFUT7Dlmyq6Wfuxsw8QBXZxXDYIQQaJ4YHaZd7s+nDMcjerLnILxjh2g3a6umtOUM+jEcRaFJAtvLZvlGfa5fw==}
+    engines: {node: '>=12.0.0'}
+    peerDependencies:
+      '@emotion/react': ^11.5.0
+      '@emotion/styled': ^11.3.0
+      '@types/react': ^17.0.0 || ^18.0.0
+      react: ^17.0.0 || ^18.0.0
+    peerDependenciesMeta:
+      '@emotion/react':
+        optional: true
+      '@emotion/styled':
+        optional: true
+      '@types/react':
+        optional: true
+    dependencies:
+      '@babel/runtime': 7.20.6
+      '@emotion/react': 11.10.5_64k6h7xsf5jw26ymy7ush5uuyi
+      '@emotion/styled': 11.10.5_ix4t66qa52ydagavywmj5pxy2q
+      '@mui/private-theming': 5.11.0_react@17.0.2
+      '@mui/styled-engine': 5.11.0_3lsrph6se4xquylogkb5yq6ogu
+      '@mui/types': 7.2.3
+      '@mui/utils': 5.11.0_react@17.0.2
+      clsx: 1.2.1
+      csstype: 3.1.1
+      prop-types: 15.8.1
+      react: 17.0.2
+    dev: false
 
   /@mui/system/5.11.0_nj4y2rcimqny27utrl764tjxdm:
     resolution: {integrity: sha512-HFUT7Dlmyq6Wfuxsw8QBXZxXDYIQQaJ4YHaZd7s+nDMcjerLnILxjh2g3a6umtOUM+jEcRaFJAtvLZvlGfa5fw==}
@@ -6172,8 +6227,8 @@ packages:
         optional: true
     dependencies:
       '@babel/runtime': 7.20.6
-      '@emotion/react': 11.10.5_nehdyrcubdy45i2h35h56gfg7i
-      '@emotion/styled': 11.10.5_wnlametqvv4n76fxzegmuwubuy
+      '@emotion/react': 11.10.5_czskpwcgwtkufrblwuek25f2b4
+      '@emotion/styled': 11.10.5_sebsp7644knzvh4a72jultvi6e
       '@mui/private-theming': 5.11.0_q5o373oqrklnndq2vhekyuzhxi
       '@mui/styled-engine': 5.11.0_3lsrph6se4xquylogkb5yq6ogu
       '@mui/types': 7.2.3_@types+react@17.0.52
@@ -8846,10 +8901,10 @@ packages:
   /@storybook/mdx1-csf/0.0.1_@babel+core@7.20.12:
     resolution: {integrity: sha512-4biZIWWzoWlCarMZmTpqcJNgo/RBesYZwGFbQeXiGYsswuvfWARZnW9RE9aUEMZ4XPn7B1N3EKkWcdcWe/K2tg==}
     dependencies:
-      '@babel/generator': 7.20.7
-      '@babel/parser': 7.20.7
+      '@babel/generator': 7.20.5
+      '@babel/parser': 7.20.5
       '@babel/preset-env': 7.20.2_@babel+core@7.20.12
-      '@babel/types': 7.20.7
+      '@babel/types': 7.20.5
       '@mdx-js/mdx': 1.6.22
       '@types/lodash': 4.14.191
       js-string-escape: 1.0.1
@@ -9771,7 +9826,7 @@ packages:
     peerDependencies:
       '@testing-library/dom': '>=7.21.4'
     dependencies:
-      '@babel/runtime': 7.20.7
+      '@babel/runtime': 7.20.6
       '@testing-library/dom': 8.19.1
     dev: false
 
@@ -10327,34 +10382,6 @@ packages:
       typescript: 4.9.4
     transitivePeerDependencies:
       - supports-color
-    dev: false
-
-  /@typescript-eslint/eslint-plugin/5.48.0_k73wpmdolxikpyqun3p36akaaq:
-    resolution: {integrity: sha512-SVLafp0NXpoJY7ut6VFVUU9I+YeFsDzeQwtK0WZ+xbRN3mtxJ08je+6Oi2N89qDn087COdO0u3blKZNv9VetRQ==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-    peerDependencies:
-      '@typescript-eslint/parser': ^5.0.0
-      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
-      typescript: '*'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-    dependencies:
-      '@typescript-eslint/parser': 5.48.0_iukboom6ndih5an6iafl45j2fe
-      '@typescript-eslint/scope-manager': 5.48.0
-      '@typescript-eslint/type-utils': 5.48.0_iukboom6ndih5an6iafl45j2fe
-      '@typescript-eslint/utils': 5.48.0_iukboom6ndih5an6iafl45j2fe
-      debug: 4.3.4
-      eslint: 8.31.0
-      ignore: 5.2.4
-      natural-compare-lite: 1.4.0
-      regexpp: 3.2.0
-      semver: 7.3.8
-      tsutils: 3.21.0_typescript@4.9.4
-      typescript: 4.9.4
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
 
   /@typescript-eslint/experimental-utils/5.46.1_ha6vam6werchizxrnqvarmz2zu:
     resolution: {integrity: sha512-M79mkB+wOuiBG8jzOVNA2h5izOip5CNPZV1K3tvE/qry/1Oh/bnKYhNWQNiH2h9O3B73YK60GmiqrUpprnQ5sQ==}
@@ -10417,27 +10444,6 @@ packages:
       typescript: 4.9.4
     transitivePeerDependencies:
       - supports-color
-    dev: false
-
-  /@typescript-eslint/parser/5.48.0_iukboom6ndih5an6iafl45j2fe:
-    resolution: {integrity: sha512-1mxNA8qfgxX8kBvRDIHEzrRGrKHQfQlbW6iHyfHYS0Q4X1af+S6mkLNtgCOsGVl8+/LUPrqdHMssAemkrQ01qg==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-    peerDependencies:
-      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
-      typescript: '*'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-    dependencies:
-      '@typescript-eslint/scope-manager': 5.48.0
-      '@typescript-eslint/types': 5.48.0
-      '@typescript-eslint/typescript-estree': 5.48.0_typescript@4.9.4
-      debug: 4.3.4
-      eslint: 8.31.0
-      typescript: 4.9.4
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
 
   /@typescript-eslint/scope-manager/5.46.1:
     resolution: {integrity: sha512-iOChVivo4jpwUdrJZyXSMrEIM/PvsbbDOX1y3UCKjSgWn+W89skxWaYXACQfxmIGhPVpRWK/VWPYc+bad6smIA==}
@@ -10445,14 +10451,6 @@ packages:
     dependencies:
       '@typescript-eslint/types': 5.46.1
       '@typescript-eslint/visitor-keys': 5.46.1
-
-  /@typescript-eslint/scope-manager/5.48.0:
-    resolution: {integrity: sha512-0AA4LviDtVtZqlyUQnZMVHydDATpD9SAX/RC5qh6cBd3xmyWvmXYF+WT1oOmxkeMnWDlUVTwdODeucUnjz3gow==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-    dependencies:
-      '@typescript-eslint/types': 5.48.0
-      '@typescript-eslint/visitor-keys': 5.48.0
-    dev: true
 
   /@typescript-eslint/type-utils/5.46.1_ha6vam6werchizxrnqvarmz2zu:
     resolution: {integrity: sha512-V/zMyfI+jDmL1ADxfDxjZ0EMbtiVqj8LUGPAGyBkXXStWmCUErMpW873zEHsyguWCuq2iN4BrlWUkmuVj84yng==}
@@ -10491,36 +10489,10 @@ packages:
       typescript: 4.9.4
     transitivePeerDependencies:
       - supports-color
-    dev: false
-
-  /@typescript-eslint/type-utils/5.48.0_iukboom6ndih5an6iafl45j2fe:
-    resolution: {integrity: sha512-vbtPO5sJyFjtHkGlGK4Sthmta0Bbls4Onv0bEqOGm7hP9h8UpRsHJwsrCiWtCUndTRNQO/qe6Ijz9rnT/DB+7g==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-    peerDependencies:
-      eslint: '*'
-      typescript: '*'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-    dependencies:
-      '@typescript-eslint/typescript-estree': 5.48.0_typescript@4.9.4
-      '@typescript-eslint/utils': 5.48.0_iukboom6ndih5an6iafl45j2fe
-      debug: 4.3.4
-      eslint: 8.31.0
-      tsutils: 3.21.0_typescript@4.9.4
-      typescript: 4.9.4
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
 
   /@typescript-eslint/types/5.46.1:
     resolution: {integrity: sha512-Z5pvlCaZgU+93ryiYUwGwLl9AQVB/PQ1TsJ9NZ/gHzZjN7g9IAn6RSDkpCV8hqTwAiaj6fmCcKSQeBPlIpW28w==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-
-  /@typescript-eslint/types/5.48.0:
-    resolution: {integrity: sha512-UTe67B0Ypius0fnEE518NB2N8gGutIlTojeTg4nt0GQvikReVkurqxd2LvYa9q9M5MQ6rtpNyWTBxdscw40Xhw==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-    dev: true
 
   /@typescript-eslint/typescript-estree/5.46.1_typescript@4.9.4:
     resolution: {integrity: sha512-j9W4t67QiNp90kh5Nbr1w92wzt+toiIsaVPnEblB2Ih2U9fqBTyqV9T3pYWZBRt6QoMh/zVWP59EpuCjc4VRBg==}
@@ -10541,27 +10513,6 @@ packages:
       typescript: 4.9.4
     transitivePeerDependencies:
       - supports-color
-
-  /@typescript-eslint/typescript-estree/5.48.0_typescript@4.9.4:
-    resolution: {integrity: sha512-7pjd94vvIjI1zTz6aq/5wwE/YrfIyEPLtGJmRfyNR9NYIW+rOvzzUv3Cmq2hRKpvt6e9vpvPUQ7puzX7VSmsEw==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-    peerDependencies:
-      typescript: '*'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-    dependencies:
-      '@typescript-eslint/types': 5.48.0
-      '@typescript-eslint/visitor-keys': 5.48.0
-      debug: 4.3.4
-      globby: 11.1.0
-      is-glob: 4.0.3
-      semver: 7.3.8
-      tsutils: 3.21.0_typescript@4.9.4
-      typescript: 4.9.4
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
 
   /@typescript-eslint/utils/5.46.1_ha6vam6werchizxrnqvarmz2zu:
     resolution: {integrity: sha512-RBdBAGv3oEpFojaCYT4Ghn4775pdjvwfDOfQ2P6qzNVgQOVrnSPe5/Pb88kv7xzYQjoio0eKHKB9GJ16ieSxvA==}
@@ -10601,40 +10552,12 @@ packages:
       - supports-color
       - typescript
 
-  /@typescript-eslint/utils/5.48.0_iukboom6ndih5an6iafl45j2fe:
-    resolution: {integrity: sha512-x2jrMcPaMfsHRRIkL+x96++xdzvrdBCnYRd5QiW5Wgo1OB4kDYPbC1XjWP/TNqlfK93K/lUL92erq5zPLgFScQ==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-    peerDependencies:
-      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
-    dependencies:
-      '@types/json-schema': 7.0.11
-      '@types/semver': 7.3.13
-      '@typescript-eslint/scope-manager': 5.48.0
-      '@typescript-eslint/types': 5.48.0
-      '@typescript-eslint/typescript-estree': 5.48.0_typescript@4.9.4
-      eslint: 8.31.0
-      eslint-scope: 5.1.1
-      eslint-utils: 3.0.0_eslint@8.31.0
-      semver: 7.3.8
-    transitivePeerDependencies:
-      - supports-color
-      - typescript
-    dev: true
-
   /@typescript-eslint/visitor-keys/5.46.1:
     resolution: {integrity: sha512-jczZ9noovXwy59KjRTk1OftT78pwygdcmCuBf8yMoWt/8O8l+6x2LSEze0E4TeepXK4MezW3zGSyoDRZK7Y9cg==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dependencies:
       '@typescript-eslint/types': 5.46.1
       eslint-visitor-keys: 3.3.0
-
-  /@typescript-eslint/visitor-keys/5.48.0:
-    resolution: {integrity: sha512-5motVPz5EgxQ0bHjut3chzBkJ3Z3sheYVcSwS5BpHZpLqSptSmELNtGixmgj65+rIfhvtQTz5i9OP2vtzdDH7Q==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-    dependencies:
-      '@typescript-eslint/types': 5.48.0
-      eslint-visitor-keys: 3.3.0
-    dev: true
 
   /@webassemblyjs/ast/1.11.1:
     resolution: {integrity: sha512-ukBh14qFLjxTQNTXocdyksN5QdM28S1CxHt2rdskFyL+xFV7VremuBLVbmCePj+URalXBENx/9Lm7lnhihtCSw==}
@@ -11042,18 +10965,18 @@ packages:
     dependencies:
       '@babel/core': 7.20.12
       '@babel/eslint-parser': 7.19.1_ucmnolur3r335ullwiyt3zl3pi
-      '@typescript-eslint/eslint-plugin': 5.48.0_k73wpmdolxikpyqun3p36akaaq
-      '@typescript-eslint/parser': 5.48.0_iukboom6ndih5an6iafl45j2fe
+      '@typescript-eslint/eslint-plugin': 5.46.1_knuev5ex3hryrh46aivii4rsoq
+      '@typescript-eslint/parser': 5.46.1_iukboom6ndih5an6iafl45j2fe
       '@wordpress/babel-preset-default': 6.17.0
       '@wordpress/prettier-config': 1.4.0_prettier@2.8.1
       cosmiconfig: 7.1.0
       eslint: 8.31.0
-      eslint-config-prettier: 8.6.0_eslint@8.31.0
-      eslint-plugin-import: 2.26.0_m2kn7xiag5lymyarkgri27ztxm
-      eslint-plugin-jest: 25.7.0_eicrjziaffed7zesw4t3fwf6ea
+      eslint-config-prettier: 8.5.0_eslint@8.31.0
+      eslint-plugin-import: 2.26.0_wvcqeaxycha2pdv7zjbjz3we2e
+      eslint-plugin-jest: 25.7.0_ttxlsobyiolshafvswprmcoj34
       eslint-plugin-jsdoc: 37.9.7_eslint@8.31.0
       eslint-plugin-jsx-a11y: 6.6.1_eslint@8.31.0
-      eslint-plugin-prettier: 3.4.1_32m5uc2milwdw3tnkcq5del26y
+      eslint-plugin-prettier: 3.4.1_xtjuwoibeoaqavcvkna3ocxxbu
       eslint-plugin-react: 7.31.11_eslint@8.31.0
       eslint-plugin-react-hooks: 4.6.0_eslint@8.31.0
       globals: 13.19.0
@@ -11951,7 +11874,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/compat-data': 7.20.5
+      '@babel/compat-data': 7.20.10
       '@babel/core': 7.20.5
       '@babel/helper-define-polyfill-provider': 0.3.3_@babel+core@7.20.5
       semver: 6.3.0
@@ -11964,7 +11887,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/compat-data': 7.20.5
+      '@babel/compat-data': 7.20.10
       '@babel/core': 7.20.7
       '@babel/helper-define-polyfill-provider': 0.3.3_@babel+core@7.20.7
       semver: 6.3.0
@@ -11990,7 +11913,7 @@ packages:
     dependencies:
       '@babel/core': 7.20.7
       '@babel/helper-define-polyfill-provider': 0.1.5_@babel+core@7.20.7
-      core-js-compat: 3.27.1
+      core-js-compat: 3.26.1
     transitivePeerDependencies:
       - supports-color
     dev: false
@@ -12013,7 +11936,7 @@ packages:
     dependencies:
       '@babel/core': 7.20.5
       '@babel/helper-define-polyfill-provider': 0.3.3_@babel+core@7.20.5
-      core-js-compat: 3.26.1
+      core-js-compat: 3.27.1
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -12025,7 +11948,7 @@ packages:
     dependencies:
       '@babel/core': 7.20.7
       '@babel/helper-define-polyfill-provider': 0.3.3_@babel+core@7.20.7
-      core-js-compat: 3.26.1
+      core-js-compat: 3.27.1
     transitivePeerDependencies:
       - supports-color
 
@@ -12596,7 +12519,7 @@ packages:
       mississippi: 3.0.0
       mkdirp: 0.5.6
       move-concurrently: 1.0.1
-      promise-inflight: 1.0.1_bluebird@3.7.2
+      promise-inflight: 1.0.1
       rimraf: 2.7.1
       ssri: 6.0.2
       unique-filename: 1.1.1
@@ -14429,8 +14352,8 @@ packages:
     dependencies:
       eslint: 8.29.0
 
-  /eslint-config-prettier/8.6.0_eslint@8.31.0:
-    resolution: {integrity: sha512-bAF0eLpLVqP5oEVUFKpMA+NnRFICwn9X8B5jrR9FcqnYBuPbqWEjTEspPWMj5ye6czoSLDweCzSo3Ko7gGrZaA==}
+  /eslint-config-prettier/8.5.0_eslint@8.31.0:
+    resolution: {integrity: sha512-obmWKLUNCnhtQRKc+tmnYuQl0pFU1ibYJQ5BGhTVB08bHe9wC8qUeG7c08dj9XX+AuPj1YSGSQIHl1pnDHZR0Q==}
     hasBin: true
     peerDependencies:
       eslint: '>=7.0.0'
@@ -14572,35 +14495,6 @@ packages:
       - supports-color
     dev: true
 
-  /eslint-module-utils/2.7.4_gauu7rrsoohvlnqdwirscmegn4:
-    resolution: {integrity: sha512-j4GT+rqzCoRKHwURX7pddtIPGySnX9Si/cgMI5ztrcqOPtk5dDEeZ34CQVPphnqkJytlc97Vuk05Um2mJ3gEQA==}
-    engines: {node: '>=4'}
-    peerDependencies:
-      '@typescript-eslint/parser': '*'
-      eslint: '*'
-      eslint-import-resolver-node: '*'
-      eslint-import-resolver-typescript: '*'
-      eslint-import-resolver-webpack: '*'
-    peerDependenciesMeta:
-      '@typescript-eslint/parser':
-        optional: true
-      eslint:
-        optional: true
-      eslint-import-resolver-node:
-        optional: true
-      eslint-import-resolver-typescript:
-        optional: true
-      eslint-import-resolver-webpack:
-        optional: true
-    dependencies:
-      '@typescript-eslint/parser': 5.48.0_iukboom6ndih5an6iafl45j2fe
-      debug: 3.2.7
-      eslint: 8.31.0
-      eslint-import-resolver-node: 0.3.6
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
   /eslint-module-utils/2.7.4_h4dlhne3g63bjzyi45ugdl2u4u:
     resolution: {integrity: sha512-j4GT+rqzCoRKHwURX7pddtIPGySnX9Si/cgMI5ztrcqOPtk5dDEeZ34CQVPphnqkJytlc97Vuk05Um2mJ3gEQA==}
     engines: {node: '>=4'}
@@ -14717,7 +14611,6 @@ packages:
       eslint-import-resolver-node: 0.3.6
     transitivePeerDependencies:
       - supports-color
-    dev: false
 
   /eslint-plugin-flowtype/8.0.3_elch3efckorx3veq6onkrpunvi:
     resolution: {integrity: sha512-dX8l6qUL6O+fYPtpNRideCFSpmWOUVx5QcaGLVqe/vlDiBSe4vYljDWDETwnyFzpl7By/WVIu6rcrniCgH9BqQ==}
@@ -14811,37 +14704,6 @@ packages:
       - supports-color
     dev: true
 
-  /eslint-plugin-import/2.26.0_m2kn7xiag5lymyarkgri27ztxm:
-    resolution: {integrity: sha512-hYfi3FXaM8WPLf4S1cikh/r4IxnO6zrhZbEGz2b660EJRbuxgpDS5gkCuYgGWg2xxh2rBuIr4Pvhve/7c31koA==}
-    engines: {node: '>=4'}
-    peerDependencies:
-      '@typescript-eslint/parser': '*'
-      eslint: ^2 || ^3 || ^4 || ^5 || ^6 || ^7.2.0 || ^8
-    peerDependenciesMeta:
-      '@typescript-eslint/parser':
-        optional: true
-    dependencies:
-      '@typescript-eslint/parser': 5.48.0_iukboom6ndih5an6iafl45j2fe
-      array-includes: 3.1.6
-      array.prototype.flat: 1.3.1
-      debug: 2.6.9
-      doctrine: 2.1.0
-      eslint: 8.31.0
-      eslint-import-resolver-node: 0.3.6
-      eslint-module-utils: 2.7.4_gauu7rrsoohvlnqdwirscmegn4
-      has: 1.0.3
-      is-core-module: 2.11.0
-      is-glob: 4.0.3
-      minimatch: 3.1.2
-      object.values: 1.1.6
-      resolve: 1.22.1
-      tsconfig-paths: 3.14.1
-    transitivePeerDependencies:
-      - eslint-import-resolver-typescript
-      - eslint-import-resolver-webpack
-      - supports-color
-    dev: true
-
   /eslint-plugin-import/2.26.0_wvcqeaxycha2pdv7zjbjz3we2e:
     resolution: {integrity: sha512-hYfi3FXaM8WPLf4S1cikh/r4IxnO6zrhZbEGz2b660EJRbuxgpDS5gkCuYgGWg2xxh2rBuIr4Pvhve/7c31koA==}
     engines: {node: '>=4'}
@@ -14871,7 +14733,6 @@ packages:
       - eslint-import-resolver-typescript
       - eslint-import-resolver-webpack
       - supports-color
-    dev: false
 
   /eslint-plugin-import/2.26.0_z7hwuz3w5sq2sbhy7d4iqrnsvq:
     resolution: {integrity: sha512-hYfi3FXaM8WPLf4S1cikh/r4IxnO6zrhZbEGz2b660EJRbuxgpDS5gkCuYgGWg2xxh2rBuIr4Pvhve/7c31koA==}
@@ -14926,27 +14787,6 @@ packages:
       - typescript
     dev: true
 
-  /eslint-plugin-jest/25.7.0_eicrjziaffed7zesw4t3fwf6ea:
-    resolution: {integrity: sha512-PWLUEXeeF7C9QGKqvdSbzLOiLTx+bno7/HC9eefePfEb257QFHg7ye3dh80AZVkaa/RQsBB1Q/ORQvg2X7F0NQ==}
-    engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
-    peerDependencies:
-      '@typescript-eslint/eslint-plugin': ^4.0.0 || ^5.0.0
-      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
-      jest: '*'
-    peerDependenciesMeta:
-      '@typescript-eslint/eslint-plugin':
-        optional: true
-      jest:
-        optional: true
-    dependencies:
-      '@typescript-eslint/eslint-plugin': 5.48.0_k73wpmdolxikpyqun3p36akaaq
-      '@typescript-eslint/experimental-utils': 5.46.1_iukboom6ndih5an6iafl45j2fe
-      eslint: 8.31.0
-    transitivePeerDependencies:
-      - supports-color
-      - typescript
-    dev: true
-
   /eslint-plugin-jest/25.7.0_ly5exmwff5fio7d4gxjjnyhwtu:
     resolution: {integrity: sha512-PWLUEXeeF7C9QGKqvdSbzLOiLTx+bno7/HC9eefePfEb257QFHg7ye3dh80AZVkaa/RQsBB1Q/ORQvg2X7F0NQ==}
     engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
@@ -14966,6 +14806,27 @@ packages:
     transitivePeerDependencies:
       - supports-color
       - typescript
+
+  /eslint-plugin-jest/25.7.0_ttxlsobyiolshafvswprmcoj34:
+    resolution: {integrity: sha512-PWLUEXeeF7C9QGKqvdSbzLOiLTx+bno7/HC9eefePfEb257QFHg7ye3dh80AZVkaa/RQsBB1Q/ORQvg2X7F0NQ==}
+    engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
+    peerDependencies:
+      '@typescript-eslint/eslint-plugin': ^4.0.0 || ^5.0.0
+      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
+      jest: '*'
+    peerDependenciesMeta:
+      '@typescript-eslint/eslint-plugin':
+        optional: true
+      jest:
+        optional: true
+    dependencies:
+      '@typescript-eslint/eslint-plugin': 5.46.1_knuev5ex3hryrh46aivii4rsoq
+      '@typescript-eslint/experimental-utils': 5.46.1_iukboom6ndih5an6iafl45j2fe
+      eslint: 8.31.0
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
+    dev: true
 
   /eslint-plugin-jest/25.7.0_zufafst33d2nodnn736pfomdre:
     resolution: {integrity: sha512-PWLUEXeeF7C9QGKqvdSbzLOiLTx+bno7/HC9eefePfEb257QFHg7ye3dh80AZVkaa/RQsBB1Q/ORQvg2X7F0NQ==}
@@ -15081,23 +14942,6 @@ packages:
       eslint-plugin-jest: 25.7.0_ly5exmwff5fio7d4gxjjnyhwtu
     dev: false
 
-  /eslint-plugin-prettier/3.4.1_32m5uc2milwdw3tnkcq5del26y:
-    resolution: {integrity: sha512-htg25EUYUeIhKHXjOinK4BgCcDwtLHjqaxCDsMy5nbnUMkKFvIhMVCp+5GFUXQ4Nr8lBsPqtGAqBenbpFqAA2g==}
-    engines: {node: '>=6.0.0'}
-    peerDependencies:
-      eslint: '>=5.0.0'
-      eslint-config-prettier: '*'
-      prettier: '>=1.13.0'
-    peerDependenciesMeta:
-      eslint-config-prettier:
-        optional: true
-    dependencies:
-      eslint: 8.31.0
-      eslint-config-prettier: 8.6.0_eslint@8.31.0
-      prettier: 2.8.1
-      prettier-linter-helpers: 1.0.0
-    dev: true
-
   /eslint-plugin-prettier/3.4.1_5dgjrgoi64tgrv3zzn3walur3u:
     resolution: {integrity: sha512-htg25EUYUeIhKHXjOinK4BgCcDwtLHjqaxCDsMy5nbnUMkKFvIhMVCp+5GFUXQ4Nr8lBsPqtGAqBenbpFqAA2g==}
     engines: {node: '>=6.0.0'}
@@ -15113,6 +14957,23 @@ packages:
       eslint-config-prettier: 8.5.0_eslint@8.29.0
       prettier: 2.8.1
       prettier-linter-helpers: 1.0.0
+
+  /eslint-plugin-prettier/3.4.1_xtjuwoibeoaqavcvkna3ocxxbu:
+    resolution: {integrity: sha512-htg25EUYUeIhKHXjOinK4BgCcDwtLHjqaxCDsMy5nbnUMkKFvIhMVCp+5GFUXQ4Nr8lBsPqtGAqBenbpFqAA2g==}
+    engines: {node: '>=6.0.0'}
+    peerDependencies:
+      eslint: '>=5.0.0'
+      eslint-config-prettier: '*'
+      prettier: '>=1.13.0'
+    peerDependenciesMeta:
+      eslint-config-prettier:
+        optional: true
+    dependencies:
+      eslint: 8.31.0
+      eslint-config-prettier: 8.5.0_eslint@8.31.0
+      prettier: 2.8.1
+      prettier-linter-helpers: 1.0.0
+    dev: true
 
   /eslint-plugin-prettier/4.2.1_5dgjrgoi64tgrv3zzn3walur3u:
     resolution: {integrity: sha512-f/0rXLXUt0oFYs8ra4w49wYZBG5GKZpAYsJSm6rnYL5uVDjd+zowwMwVZHnAjf4edNrKpCDYfXDgmRE/Ak7QyQ==}
@@ -21406,16 +21267,6 @@ packages:
       bluebird:
         optional: true
 
-  /promise-inflight/1.0.1_bluebird@3.7.2:
-    resolution: {integrity: sha512-6zWPyEOFaQBJYcGMHBKTKJ3u6TBsnMFOIZSa6ce1e/ZrrsOlnHRHbabMjLiBYKp+n44X9eUI6VUPaukCXHuG4g==}
-    peerDependencies:
-      bluebird: '*'
-    peerDependenciesMeta:
-      bluebird:
-        optional: true
-    dependencies:
-      bluebird: 3.7.2
-
   /promise.allsettled/1.0.6:
     resolution: {integrity: sha512-22wJUOD3zswWFqgwjNHa1965LvqTX87WPu/lreY2KSd7SVcERfuZ4GfUaOnJNnvtoIv2yXT/W00YIGMetXtFXg==}
     engines: {node: '>= 0.4'}
@@ -22507,10 +22358,6 @@ packages:
       rollup: '*'
     dependencies:
       rollup: 2.79.1
-    dev: true
-
-  /rollup-plugin-shell/1.0.9:
-    resolution: {integrity: sha512-PdpbYuTN9Pkc9to07DQOWy71pfvpI0tpvKXsWlgdpU4GL4l5yniKVldTrkqr6qI6M02lEkRVoU/0Hme5VKs39g==}
     dev: true
 
   /rollup-plugin-terser/7.0.2_rollup@2.79.1:

--- a/tooling/rollup-config/src/index.js
+++ b/tooling/rollup-config/src/index.js
@@ -9,7 +9,6 @@ import typescript from '@rollup/plugin-typescript';
 import { terser } from 'rollup-plugin-terser';
 import peerDepsExternal from 'rollup-plugin-peer-deps-external';
 import copy from 'rollup-plugin-copy'
-import execute from "rollup-plugin-shell";
 
 const pkg = JSON.parse(readFileSync(resolve(cwd(), './package.json')));
 const isProd = process.env.NODE_ENV === 'production';
@@ -47,10 +46,6 @@ export const esmConfig = defineConfig({
     }),
     ...defaultPlugins,
     typescript({ tsconfig: resolve(cwd(), './tsconfig.json'), outputToFilesystem: true }),
-    execute({
-      commands: process.env.yalc === 'true' ? ['yalc push --sig'] : [],
-      hook: 'writeBundle'
-    })
   ],
   external: ['react', 'react-dom', 'styled-components', 'use-query-params'],
 });


### PR DESCRIPTION
- Swap `React. ComponentType` for `React. FunctionComponent` on `Loadable` component to fix TS error.
- Removes previous local dev work and yalc, since they're no longer necessary.