### PR TITLE
[MAD-12109] Handle 'null' package in domain search

### DIFF
--- a/.changeset/large-flowers-provide.md
+++ b/.changeset/large-flowers-provide.md
@@ -1,0 +1,5 @@
+---
+'@moderntribe/sitebuilder': patch
+---
+
+Adds fix to handle null domain search package property

--- a/packages/sitebuilder/src/utils/parseDomainListItem.ts
+++ b/packages/sitebuilder/src/utils/parseDomainListItem.ts
@@ -10,8 +10,8 @@ type DomainListItem = {
 	selected: boolean,
 }
 
-function getPrice(termFees: DomainTermFees, isAvailable: boolean) {
-	if (! isAvailable) {
+function getPrice(termFees: DomainTermFees | undefined, isAvailable: boolean) {
+	if (! termFees || ! isAvailable) {
 		return undefined;
 	}
 
@@ -31,8 +31,11 @@ function getPrice(termFees: DomainTermFees, isAvailable: boolean) {
 	);
 }
 
-function getChipLabel(isAvailable: boolean, isSelected: boolean) {
-	if (! isAvailable) {
+function getChipLabel(domain: Domain, isSelected: boolean) {
+	if (! domain.package) {
+		return GoLiveStringData.domainItems.unavailable;
+	}
+	if (! domain.is_available) {
 		return GoLiveStringData.domainItems.taken;
 	}
 	if (isSelected) {
@@ -52,8 +55,8 @@ export function parseDomainListItem(domain: Domain, selected: boolean): DomainLi
 	return ({
 		name: domain.domain,
 		disabled: ! domain.is_available,
-		price: getPrice(domain.package.term_fees, domain.is_available),
-		chipLabel: getChipLabel(domain.is_available, selected),
+		price: getPrice(domain.package?.term_fees, domain.is_available),
+		chipLabel: getChipLabel(domain, selected),
 		chipColor: getChipColor(domain.is_available, selected),
 		selected,
 	});

--- a/packages/sitebuilder/src/wizards/go-live/data/constants.ts
+++ b/packages/sitebuilder/src/wizards/go-live/data/constants.ts
@@ -83,5 +83,6 @@ export const GoLiveStringData = {
 		taken: __('Taken', 'moderntribe-sitebuilder'),
 		selected: __('Selected', 'moderntribe-sitebuilder'),
 		available: __('Available', 'moderntribe-sitebuilder'),
+		unavailable: __('Unavailable', 'moderntribe-sitebuilder'),
 	}
 };


### PR DESCRIPTION
Updates `getPrice` and `getChipLabel` functions to handle `package: null` scenario.