### PR TITLE
Bugfix: payment gateway code cleanup

### DIFF
--- a/plugins/wme-sitebuilder/wme-sitebuilder/Wizards/PaymentGatewayPayPal.php
+++ b/plugins/wme-sitebuilder/wme-sitebuilder/Wizards/PaymentGatewayPayPal.php
@@ -33,7 +33,7 @@ class PaymentGatewayPayPal extends Wizard {
 	/**
 	 * Construct.
 	 *
-	 * @param PayPal $plugin
+	 * @param  PayPal  $plugin
 	 */
 	public function __construct( PayPal $plugin ) {
 		$this->plugin = $plugin;
@@ -83,29 +83,29 @@ class PaymentGatewayPayPal extends Wizard {
 	 */
 	public function installPlugin() {
 		if ( ! current_user_can( 'install_plugins' ) ) {
-			wp_send_json_error(new WP_Error(
+			wp_send_json_error( new WP_Error(
 				'mapps-capabilities-failure',
 				__( 'You do not have permission to perform this action. Please contact a site administrator.', 'wme-sitebuilder' )
-			), 403);
+			), 403 );
 		}
 
-		$response = $this->makeCommand('wp plugin install', [
+		$response = $this->makeCommand( 'wp plugin install', [
 			$this->plugin->slug,
 			'--activate',
 			sprintf( '--version=%s', $this->plugin->supported_version ),
 			'--force',
-		])->execute();
+		] )->execute();
 
 		if ( ! $response->wasSuccessful() ) {
-			wp_send_json_error(new WP_Error(
+			wp_send_json_error( new WP_Error(
 				'mapps-wpcli-error',
 				sprintf(
-					/* Translators: %1$s is the exit code from WP CLI; %2$s is output from WP CLI. */
+				/* Translators: %1$s is the exit code from WP CLI; %2$s is output from WP CLI. */
 					__( 'Encountered WP CLI exit code "%1$s" with output "%2$s".', 'wme-sitebuilder' ),
 					sanitize_text_field( $response->getExitCode() ),
 					sanitize_text_field( $response->getOutput() )
 				)
-			), 500);
+			), 500 );
 		}
 
 		wp_send_json_success( null, 200 );
@@ -118,10 +118,10 @@ class PaymentGatewayPayPal extends Wizard {
 	 */
 	public function getKeys() {
 		if ( ! current_user_can( 'manage_options' ) ) {
-			wp_send_json_error(new WP_Error(
+			wp_send_json_error( new WP_Error(
 				'mapps-capabilities-failure',
 				__( 'You do not have permission to perform this action. Please contact a site administrator.', 'wme-sitebuilder' )
-			), 403);
+			), 403 );
 		}
 
 		wp_send_json_success( $this->plugin->keys );
@@ -134,10 +134,10 @@ class PaymentGatewayPayPal extends Wizard {
 	 */
 	public function oauthProps() {
 		if ( ! current_user_can( 'install_plugins' ) ) {
-			wp_send_json_error(new WP_Error(
+			wp_send_json_error( new WP_Error(
 				'mapps-capabilities-failure',
 				__( 'You do not have permission to perform this action. Please contact a site administrator.', 'wme-sitebuilder' )
-			), 403);
+			), 403 );
 		}
 
 		$data = [
@@ -170,7 +170,7 @@ class PaymentGatewayPayPal extends Wizard {
 	 *
 	 * Redirect completion of PayPal oAuth workflow back into wizard.
 	 *
-	 * @param string $location
+	 * @param  string  $location
 	 *
 	 * @return string
 	 */
@@ -182,8 +182,9 @@ class PaymentGatewayPayPal extends Wizard {
 		// The ?step is not a query parameter, so we need to add it here.
 		$query_param_page = $this->admin_page_slug . '#/wizard/payments-paypal?step=2';
 
-		return add_query_arg([
+		return add_query_arg( [
 			'page' => $query_param_page,
-		], admin_url( 'admin.php' ));
+		], admin_url( 'admin.php' ) );
 	}
+
 }

--- a/plugins/wme-sitebuilder/wme-sitebuilder/Wizards/PaymentGatewayPayPal.php
+++ b/plugins/wme-sitebuilder/wme-sitebuilder/Wizards/PaymentGatewayPayPal.php
@@ -67,19 +67,23 @@ class PaymentGatewayPayPal extends Wizard {
 
 	/**
 	 * Telemetry: wizard started.
+	 *
+	 * @return never
 	 */
 	public function telemetryWizardStarted() {
 		do_action( 'wme_event_wizard_started', sprintf( 'payment-%s', $this->plugin->slug ) );
 
-		return wp_send_json_success();
+		wp_send_json_success();
 	}
 
 	/**
 	 * AJAX: Install plugin.
+	 *
+	 * @return never
 	 */
 	public function installPlugin() {
 		if ( ! current_user_can( 'install_plugins' ) ) {
-			return wp_send_json_error(new WP_Error(
+			wp_send_json_error(new WP_Error(
 				'mapps-capabilities-failure',
 				__( 'You do not have permission to perform this action. Please contact a site administrator.', 'wme-sitebuilder' )
 			), 403);
@@ -109,6 +113,8 @@ class PaymentGatewayPayPal extends Wizard {
 
 	/**
 	 * AJAX: Provide PayPal keys.
+	 *
+	 * @return never
 	 */
 	public function getKeys() {
 		if ( ! current_user_can( 'manage_options' ) ) {
@@ -123,6 +129,8 @@ class PaymentGatewayPayPal extends Wizard {
 
 	/**
 	 * AJAX: Provide oAuth properties.
+	 *
+	 * @return never
 	 */
 	public function oauthProps() {
 		if ( ! current_user_can( 'install_plugins' ) ) {
@@ -142,11 +150,13 @@ class PaymentGatewayPayPal extends Wizard {
 
 	/**
 	 * Telemetry: wizard completed.
+	 *
+	 * @return never
 	 */
 	public function telemetryWizardCompleted() {
 		do_action( 'wme_event_wizard_started', sprintf( 'payment-%s', $this->plugin->slug ) );
 
-		return wp_send_json_success();
+		wp_send_json_success();
 	}
 
 	/**

--- a/plugins/wme-sitebuilder/wme-sitebuilder/Wizards/PaymentGatewayStripe.php
+++ b/plugins/wme-sitebuilder/wme-sitebuilder/Wizards/PaymentGatewayStripe.php
@@ -67,19 +67,23 @@ class PaymentGatewayStripe extends Wizard {
 
 	/**
 	 * Telemetry: wizard started.
+	 *
+	 * @return never
 	 */
 	public function telemetryWizardStarted() {
 		do_action( 'wme_event_wizard_started', sprintf( 'payment-%s', $this->plugin->slug ) );
 
-		return wp_send_json_success();
+		wp_send_json_success();
 	}
 
 	/**
 	 * AJAX: Install plugin.
+	 *
+	 * @return never
 	 */
 	public function installPlugin() {
 		if ( ! current_user_can( 'install_plugins' ) ) {
-			return wp_send_json_error(new WP_Error(
+			wp_send_json_error(new WP_Error(
 				'mapps-capabilities-failure',
 				__( 'You do not have permission to perform this action. Please contact a site administrator.', 'wme-sitebuilder' )
 			), 403);
@@ -109,6 +113,8 @@ class PaymentGatewayStripe extends Wizard {
 
 	/**
 	 * AJAX: Provide oAuth URL.
+	 *
+	 * @return never
 	 */
 	public function oauthUrl() {
 		if ( ! current_user_can( 'install_plugins' ) ) {
@@ -123,6 +129,8 @@ class PaymentGatewayStripe extends Wizard {
 
 	/**
 	 * AJAX: Provide Stripe keys.
+	 *
+	 * @return never
 	 */
 	public function getKeys() {
 		if ( ! current_user_can( 'manage_options' ) ) {
@@ -137,11 +145,13 @@ class PaymentGatewayStripe extends Wizard {
 
 	/**
 	 * Telemetry: wizard completed.
+	 *
+	 * @return never
 	 */
 	public function telemetryWizardCompleted() {
 		do_action( 'wme_event_wizard_completed', sprintf( 'payment-%s', $this->plugin->slug ) );
 
-		return wp_send_json_success();
+		wp_send_json_success();
 	}
 
 	/**

--- a/plugins/wme-sitebuilder/wme-sitebuilder/Wizards/PaymentGatewayStripe.php
+++ b/plugins/wme-sitebuilder/wme-sitebuilder/Wizards/PaymentGatewayStripe.php
@@ -33,7 +33,7 @@ class PaymentGatewayStripe extends Wizard {
 	/**
 	 * Construct.
 	 *
-	 * @param Stripe $plugin
+	 * @param  Stripe  $plugin
 	 */
 	public function __construct( Stripe $plugin ) {
 		$this->plugin = $plugin;
@@ -83,29 +83,29 @@ class PaymentGatewayStripe extends Wizard {
 	 */
 	public function installPlugin() {
 		if ( ! current_user_can( 'install_plugins' ) ) {
-			wp_send_json_error(new WP_Error(
+			wp_send_json_error( new WP_Error(
 				'mapps-capabilities-failure',
 				__( 'You do not have permission to perform this action. Please contact a site administrator.', 'wme-sitebuilder' )
-			), 403);
+			), 403 );
 		}
 
-		$response = $this->makeCommand('wp plugin install', [
+		$response = $this->makeCommand( 'wp plugin install', [
 			$this->plugin->slug,
 			'--activate',
 			sprintf( '--version=%s', $this->plugin->supported_version ),
 			'--force',
-		])->execute();
+		] )->execute();
 
 		if ( ! $response->wasSuccessful() ) {
-			wp_send_json_error(new WP_Error(
+			wp_send_json_error( new WP_Error(
 				'mapps-wpcli-error',
 				sprintf(
-					/* Translators: %1$s is the exit code from WP CLI; %2$s is output from WP CLI. */
+				/* Translators: %1$s is the exit code from WP CLI; %2$s is output from WP CLI. */
 					__( 'Encountered WP CLI exit code "%1$s" with output "%2$s".', 'wme-sitebuilder' ),
 					sanitize_text_field( $response->getExitCode() ),
 					sanitize_text_field( $response->getOutput() )
 				)
-			), 500);
+			), 500 );
 		}
 
 		wp_send_json_success( null, 200 );
@@ -118,10 +118,10 @@ class PaymentGatewayStripe extends Wizard {
 	 */
 	public function oauthUrl() {
 		if ( ! current_user_can( 'install_plugins' ) ) {
-			wp_send_json_error(new WP_Error(
+			wp_send_json_error( new WP_Error(
 				'mapps-capabilities-failure',
 				__( 'You do not have permission to perform this action. Please contact a site administrator.', 'wme-sitebuilder' )
-			), 403);
+			), 403 );
 		}
 
 		wp_send_json_success( $this->plugin->oauth_url, 200 );
@@ -134,10 +134,10 @@ class PaymentGatewayStripe extends Wizard {
 	 */
 	public function getKeys() {
 		if ( ! current_user_can( 'manage_options' ) ) {
-			wp_send_json_error(new WP_Error(
+			wp_send_json_error( new WP_Error(
 				'mapps-capabilities-failure',
 				__( 'You do not have permission to perform this action. Please contact a site administrator.', 'wme-sitebuilder' )
-			), 403);
+			), 403 );
 		}
 
 		wp_send_json_success( $this->plugin->keys );
@@ -165,9 +165,9 @@ class PaymentGatewayStripe extends Wizard {
 	 *
 	 * Redirect completion of Stripe oAuth workflow back into wizard.
 	 *
-	 * @see WC_Stripe_Connect::maybe_handle_redirect()
+	 * @param  string  $location
 	 *
-	 * @param string $location
+	 * @see WC_Stripe_Connect::maybe_handle_redirect()
 	 *
 	 * @return string
 	 */
@@ -188,4 +188,5 @@ class PaymentGatewayStripe extends Wizard {
 			'page' => $query_param_page,
 		], admin_url( 'admin.php' ) );
 	}
+
 }


### PR DESCRIPTION
- Remove returns of void functions.
- Add `@return never` docBlocks, as wp_send_json_* will always execute `die` at the end.
- Update code formatting.