### PR TITLE
feature: Adding target prop to SetupCardTask component, reformatting domain setup card

### DIFF
--- a/packages/sitebuilder/sitebuilder.d.ts
+++ b/packages/sitebuilder/sitebuilder.d.ts
@@ -65,6 +65,7 @@ declare global {
 		icon?: React.ReactElement | string;
 		taskCta?: string;
 		url?: string;
+		target?: '_blank' | '_self';
 		wizardHash?: string;
 	}
 

--- a/packages/sitebuilder/src/setup/GoLiveStatus.tsx
+++ b/packages/sitebuilder/src/setup/GoLiveStatus.tsx
@@ -79,7 +79,7 @@ const GoLiveStatus: React.FC<GoLiveStatusInterface> = (props) => {
 	};
 
 	return <SetupCardInfoRow
-		sx={ { marginBottom: '8px' } }
+		sx={ { mb: 3 } }
 		primary={ ! completed && !! capturedDomain ? <RetryStatus domain={ capturedDomain } /> : <StandardStatus domain={ domain } completed={ completed } /> }
 		secondary={ (completed || !! capturedDomain) && (
 			<Link

--- a/packages/sitebuilder/src/setup/SetupCardTask.tsx
+++ b/packages/sitebuilder/src/setup/SetupCardTask.tsx
@@ -19,6 +19,7 @@ const getAvatarProps = (props: SetupCardRowInterface) => {
 const SetupCardTask = (props: SetupCardRowInterface) => {
 	const {
 		url,
+		target,
 		wizardHash,
 		...rest
 	} = props;
@@ -39,6 +40,7 @@ const SetupCardTask = (props: SetupCardRowInterface) => {
 		{ ...rest }
 		onClick={ ! validUrl && wizardHash ? handleOnClick : undefined }
 		href={ validUrl ? url : undefined }
+		target={ validUrl ? target : undefined }
 		icon={ Object.keys(avatarProps).length > 0 && (<Icon><img { ...avatarProps } alt="icon" /></Icon>) }
 	/>;
 };

--- a/packages/sitebuilder/src/setup/data/constants.ts
+++ b/packages/sitebuilder/src/setup/data/constants.ts
@@ -7,7 +7,7 @@ export const SetupData = {
 	},
 	goLiveStatus: {
 		manage: __('Manage', 'moderntribe-sitebuilder'),
-		statusMessage: __('Your site is currently at', 'moderntribe-sitebuilder'),
+		statusMessage: __('Your site domain is', 'moderntribe-sitebuilder'),
 		tryAgain: __('Try Again', 'moderntribe-sitebuilder'),
 		verifyMsgPart1: __('We were unable to verify', 'moderntribe-sitebuilder'),
 		verifyMsgPart2: __('Try again in 8-12 hrs after your last attempt.', 'moderntribe-sitebuilder'),

--- a/packages/wme-ui/src/components/setup-card-task/setup-card-task-action.tsx
+++ b/packages/wme-ui/src/components/setup-card-task/setup-card-task-action.tsx
@@ -7,8 +7,7 @@ import {
   TypographyProps,
 } from '@mui/material';
 import { styled } from '@mui/system';
-import ChevronRight from '@mui/icons-material/ChevronRight';
-import CheckCircleIcon from '@mui/icons-material/CheckCircle';
+import { CheckCircle, ChevronRight, Launch } from '@mui/icons-material';
 import type { SetupCardTaskProps } from './setup-card-task';
 
 const ArrowWrapper = styled(Box, {
@@ -39,7 +38,7 @@ const PopupAction = styled(Typography, {
   },
 }));
 
-const CompleteCheckmark = styled(CheckCircleIcon, {
+const CompleteCheckmark = styled(CheckCircle, {
   name: 'WmeCheckmark',
   slot: 'Root',
 })(({ theme }) => ({
@@ -49,8 +48,10 @@ const CompleteCheckmark = styled(CheckCircleIcon, {
   color: theme.palette.success.main,
 }));
 
-const SetupCardAction = (props: Pick<SetupCardTaskProps, 'button' | 'taskCta' | 'isComplete'>) => {
-  const { button, taskCta, isComplete } = props;
+const SetupCardAction = (props: Pick<SetupCardTaskProps, 'button' | 'target' | 'taskCta' | 'isComplete'>) => {
+  const {
+    button, target, taskCta, isComplete,
+  } = props;
 
   if (isComplete) {
     return (
@@ -62,6 +63,16 @@ const SetupCardAction = (props: Pick<SetupCardTaskProps, 'button' | 'taskCta' | 
 
   if (button) {
     return button;
+  }
+
+  if (target === '_blank') {
+    return (
+      <ArrowWrapper>
+        <Launch
+          sx={{ fontSize: '1rem' }}
+        />
+      </ArrowWrapper>
+    );
   }
 
   return (

--- a/packages/wme-ui/src/components/setup-card-task/setup-card-task-wrapper.tsx
+++ b/packages/wme-ui/src/components/setup-card-task/setup-card-task-wrapper.tsx
@@ -6,15 +6,16 @@ import {
 } from '@mui/material';
 import type { SetupCardTaskProps } from './setup-card-task';
 
-const CardContentWrapper = (props: Pick<SetupCardTaskProps, 'href' | 'onClick' | 'children' | 'button' | 'disabled'>) => {
+const CardContentWrapper = (props: Pick<SetupCardTaskProps, 'href' | 'target' | 'onClick' | 'children' | 'button' | 'disabled'>) => {
   const {
-    onClick, href, button, children, disabled,
+    onClick, href, target, button, children, disabled,
   } = props;
 
   if (!button) {
     return (
       <CardActionArea
         {...(href ? { href } : {})}
+        {...(target ? { target } : {})}
         {...(onClick ? { onClick } : {})}
         disabled={disabled}
         className="WmeTask-content-wrapper"

--- a/packages/wme-ui/src/components/setup-card-task/setup-card-task.stories.mdx
+++ b/packages/wme-ui/src/components/setup-card-task/setup-card-task.stories.mdx
@@ -35,6 +35,11 @@ import CalendarMonthIcon from "@mui/icons-material/CalendarMonth";
 				},
 			},
 		},
+		target: {
+			control: "select",
+			description: "The target attribute for the link.",
+			options: ["_blank", "_self"],
+		},
 		taskCta: {
 			control: "text",
 			description: "The hover pop-up text for tasks without a button",

--- a/packages/wme-ui/src/components/setup-card-task/setup-card-task.tsx
+++ b/packages/wme-ui/src/components/setup-card-task/setup-card-task.tsx
@@ -15,6 +15,7 @@ export interface SetupCardTaskProps extends BoxProps {
   icon?: React.ReactNode;
   button?: React.ReactElement;
   href?: string;
+  target?: '_blank' | '_self';
   onClick?: (event: React.MouseEvent<HTMLElement>) => void;
   disabled?: boolean;
   taskCta?: string;
@@ -89,6 +90,7 @@ const SetupCardTask = (props: SetupCardTaskProps) => {
     intro,
     icon,
     href,
+    target,
     onClick,
     button,
     disabled,
@@ -107,7 +109,13 @@ const SetupCardTask = (props: SetupCardTaskProps) => {
 
   return (
     <Task className="WmeTask-root">
-      <CardContentWrapper href={href} onClick={onClick} button={button} disabled={disabled}>
+      <CardContentWrapper
+        href={href}
+        target={target}
+        onClick={onClick}
+        button={button}
+        disabled={disabled}
+      >
         <Box className="WmeTask-content">
           {icon && <TaskIcon className="WmeTaskIcon-wrapper">{icon}</TaskIcon>}
           <Box sx={{ mr: 2 }}>
@@ -115,7 +123,12 @@ const SetupCardTask = (props: SetupCardTaskProps) => {
             {intro && <Typography variant="body1">{intro}</Typography>}
           </Box>
         </Box>
-        <SetupCardAction button={actionElement} taskCta={taskCta} isComplete={isComplete} />
+        <SetupCardAction
+          button={actionElement}
+          target={target}
+          taskCta={taskCta}
+          isComplete={isComplete}
+        />
       </CardContentWrapper>
     </Task>
   );

--- a/plugins/wme-sitebuilder/wme-sitebuilder/Cards/GoLive.php
+++ b/plugins/wme-sitebuilder/wme-sitebuilder/Cards/GoLive.php
@@ -42,7 +42,7 @@ class GoLive extends Card {
 			'id'        => 'launch-domain',
 			'navTitle'     => __( 'Domain', 'wme-sitebuilder' ),
 			'title'     => __( 'Your Domain', 'wme-sitebuilder' ),
-			'intro'     => __( 'Go live with a custom domain, whether you purchased with Nexcess or elsewhere.', 'wme-sitebuilder' ),
+			'intro'     => __( 'Update your sites domain.', 'wme-sitebuilder' ),
 			'completed' => $this->wizard->isComplete(),
 			'rows'      => [
 				[
@@ -50,48 +50,19 @@ class GoLive extends Card {
 					'type' => 'launch-domain-status',
 				],
 			],
-			'footer' => $this->footer(),
 		];
 
 		if ( ! $this->wizard->isComplete() ) {
 			$details['rows'][] = [
 				'id'         => 'site-domain-wizard',
 				'type'       => 'task',
-				'title'      => __( 'Purchase a domain', 'wme-sitebuilder' ),
-				'intro'      => __( 'Don\'t own a domain? Purchase a custom domain for your site.', 'wme-sitebuilder' ),
-				'taskCta'    => __( 'Get Started', 'wme-sitebuilder' ),
-				'wizardHash' => '/wizard/go-live-purchase',
-			];
-
-			$details['rows'][] = [
-				'id'         => 'site-domain-wizard',
-				'type'       => 'task',
-				'title'      => __( 'Connect your domain', 'wme-sitebuilder' ),
-				'intro'      => __( 'Already own a domain? Update your store URL with your custom domain.', 'wme-sitebuilder' ),
-				'taskCta'    => __( 'Get Started', 'wme-sitebuilder' ),
-				'wizardHash' => '/wizard/go-live-connect',
+				'title'      => __( 'Publish your site with a custom domain', 'wme-sitebuilder' ),
+				'intro'      => __( 'Update your site URL with a custom domain you own', 'wme-sitebuilder' ),
+				'url'        => 'https://www.nexcess.net/help/guide-to-going-live-with-storebuilder/',
+				'target'     => '_blank',
 			];
 		}
 
 		return $details;
-	}
-
-	protected function footer() {
-		return [
-			'collapsible' => false,
-			'rows'        => [
-				[
-					'type'  => 'links',
-					'title' => __( 'Need help?', 'wme-sitebuilder' ),
-					'links' => [
-						[
-							'label'  => __( 'Our Guide To Going Live', 'wme-sitebuilder' ),
-							'target' => '__blank',
-							'href'   => 'https://www.nexcess.net/help/guide-to-going-live-with-storebuilder/',
-						]
-					]
-				]
-			]
-		];
 	}
 }


### PR DESCRIPTION
- Target prop added to the SetupCardTask component to handle external link navigations
![Screen Capture on 2023-03-13 at 13-09-40](https://user-images.githubusercontent.com/4440378/224675732-5e3fa297-0270-4dfe-81fd-c72098dec280.gif)

- Domain card has been reformatted according to the new link target improvement
![Screen Capture on 2023-03-13 at 13-18-27](https://user-images.githubusercontent.com/4440378/224675902-2432d9c2-ac8f-4da0-8163-b5cd9b6a311d.gif)
