### PR TITLE
[SITE-289] BE: Google Analytics Card

### DIFF
--- a/plugins/wme-sitebuilder/wme-sitebuilder/Cards/GoogleAnalytics.php
+++ b/plugins/wme-sitebuilder/wme-sitebuilder/Cards/GoogleAnalytics.php
@@ -2,7 +2,18 @@
 
 namespace Tribe\WME\Sitebuilder\Cards;
 
+use Tribe\WME\Sitebuilder\Concerns\StoresData;
+
 class GoogleAnalytics extends Card {
+
+	use StoresData;
+
+	const DATA_STORE_NAME = 'wme_sitebuilder_google_analytics';
+
+	/**
+	 * @var string
+	 */
+	protected $ajax_action = 'sitebuilder-google-analytics';
 
 	/**
 	 * @var string
@@ -14,13 +25,14 @@ class GoogleAnalytics extends Card {
 	 */
 	protected $card_slug = 'google-analytics';
 
-
 	/**
 	 * Construct.
 	 *
 	 */
 	public function __construct() {
 		parent::__construct();
+
+		$this->add_ajax_action( 'save', [ $this, 'save' ] );
 	}
 
 	/**
@@ -37,5 +49,34 @@ class GoogleAnalytics extends Card {
 		];
 
 		return $details;
+	}
+
+	/**
+	 * Save the escape the code and save it to the database.
+	 *
+	 * @return array
+	 */
+	public function save() {
+		$code = $_REQUEST['code'] ?? '';
+
+		// Escape the code.
+		$code = esc_html( $code );
+
+		if ( empty( $code ) ) {
+			return wp_send_json_error(
+				[
+					'code' => $code,
+				]
+			);
+		}
+
+		// Save the code.
+		$this->getData()->set( 'code', $code )->save();
+
+		return wp_send_json_success(
+			[
+				'code' => $this->getData()->get( 'code' ),
+			]
+		);
 	}
 }

--- a/plugins/wme-sitebuilder/wme-sitebuilder/Cards/GoogleAnalytics.php
+++ b/plugins/wme-sitebuilder/wme-sitebuilder/Cards/GoogleAnalytics.php
@@ -46,6 +46,7 @@ class GoogleAnalytics extends Card {
 			'navTitle'     => __( 'Google Analytics', 'wme-sitebuilder' ),
 			'title'     => __( 'Google Analytics', 'wme-sitebuilder' ),
 			'intro'     => __( 'Google Analytics enables you to track the visitors to your site and generate reports.', 'wme-sitebuilder' ),
+			'code'      => html_entity_decode( $this->getData()->get( 'code' ) ?? '' ),
 		];
 
 		return $details;

--- a/plugins/wme-sitebuilder/wme-sitebuilder/Cards/GoogleAnalytics.php
+++ b/plugins/wme-sitebuilder/wme-sitebuilder/Cards/GoogleAnalytics.php
@@ -52,7 +52,7 @@ class GoogleAnalytics extends Card {
 	}
 
 	/**
-	 * Save the escape the code and save it to the database.
+	 * Escape the code and save it to the database.
 	 *
 	 * @return array
 	 */


### PR DESCRIPTION
Adds save endpoint:

/wp-admin/admin-ajax.php?action=sitebuilder-google-analytics&sub_action=save&_wpnonce=<none>&code=<code_from_input>

Adds required props to the card:

![Screenshot 2023-04-12 at 12 28 45](https://user-images.githubusercontent.com/45258742/231444039-1df8e5f0-9cbe-4c1a-9705-f987d32155a8.png)
