### PR TITLE
[1.0]: Bugfix - Use the Tr1b0t token + info to split monorepo packages

### DIFF
--- a/.github/workflows/split.yml
+++ b/.github/workflows/split.yml
@@ -9,7 +9,7 @@ on:
       - '*'
 
 env:
-  GITHUB_TOKEN: ${{ secrets.SPLIT_ACCESS_TOKEN }}
+  GITHUB_TOKEN: ${{ secrets.GH_BOT_TOKEN }}
 
 jobs:
   packages_split:
@@ -40,8 +40,8 @@ jobs:
           repository_name: '${{ matrix.package.split_repository }}'
                     
           # ↓ the user signed under the split commit
-          user_name: "bswatson"
-          user_email: "brian@tri.be"
+          user_name: "Tr1b0t"
+          user_email: "Tr1b0t@users.noreply.github.com"
           
           branch: '${{ github.ref_name }}'
       
@@ -60,5 +60,5 @@ jobs:
           repository_name: '${{ matrix.package.split_repository }}'
           
           # ↓ the user signed under the split commit
-          user_name: "bswatson"
-          user_email: "brian@tri.be"
+          user_name: "Tr1b0t"
+          user_email: "Tr1b0t@users.noreply.github.com"


### PR DESCRIPTION
Monorepo splitting is broken because it's using Brian's token, which no longer has access. This updates to the more standard Tr1b0t token which should have proper access to write to the split repos for this project.