### PR TITLE
[1.0]: Bugfix - Make the Manage PayPal and Manage Stripe buttons link

### DIFF
--- a/plugins/wme-sitebuilder/wme-sitebuilder/Plugins/PaymentGateways/PayPal.php
+++ b/plugins/wme-sitebuilder/wme-sitebuilder/Plugins/PaymentGateways/PayPal.php
@@ -82,6 +82,7 @@ class PayPal extends Plugin {
 			'icon'        => 'setup-icon-paypal.png',
 			'disableText' => __( 'Manage PayPal', 'wme-sitebuilder' ),
 			'adminUrl'    => $this->admin_url,
+			'url'         => $this->admin_url,
 			'connected'   => $this->connected,
 			'button'      => [
 				'label'           => __( 'Connect PayPal', 'wme-sitebuilder' ),

--- a/plugins/wme-sitebuilder/wme-sitebuilder/Plugins/PaymentGateways/Stripe.php
+++ b/plugins/wme-sitebuilder/wme-sitebuilder/Plugins/PaymentGateways/Stripe.php
@@ -80,6 +80,7 @@ class Stripe extends Plugin {
 			'icon'        => 'setup-icon-stripe.png',
 			'disableText' => __( 'Manage Stripe', 'wme-sitebuilder' ),
 			'adminUrl'    => $this->admin_url,
+			'url'         => $this->admin_url,
 			'connected'   => $this->connected,
 			'button'      => [
 				'label'           => __( 'Connect Stripe', 'wme-sitebuilder' ),


### PR DESCRIPTION
These are currently broken after you've connected the accounts and clicking the buttons do nothing. 

This makes those buttons link to their Woo admin pages to manage them.